### PR TITLE
Document missing genome_entropy methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ genome_entropy ml train --split-dir results/ --output model.ubj \
     --json-output detailed_results.json
 
 # Make predictions on new data
-genome_entropy ml predict --json-dir new_results/ --model model.ubj --output predictions.csv
+genome_entropy ml predict --json-dir new_results/ --model model.ubj --output predictions.tsv
 ```
 
 **Two modes of operation:**
@@ -256,20 +256,25 @@ genome_entropy run \
     --output results.json \
     --table 11 \
     --min-aa 30 \
-    --model Rostlab/ProstT5_fp16 \
+    --model gbouras13/modernprost-base \
     --device auto
 ```
 
 **Options:**
-- `--input, -i`: Input FASTA file (required)
+- `--input, -i`: Input FASTA file (required if `--genbank` is not provided)
+- `--genbank, -g`: GenBank file with DNA sequences and CDS annotations
 - `--output, -o`: Output JSON file (required)
 - `--table, -t`: NCBI genetic code table ID (default: 11)
 - `--min-aa`: Minimum protein length in amino acids (default: 30)
-- `--model, -m`: Model name (default: Rostlab/ProstT5_fp16)
-  - `Rostlab/ProstT5_fp16` - Original ProstT5 model
+- `--model, -m`: Model name (default: `gbouras13/modernprost-base`)
   - `gbouras13/modernprost-base` - Newer ModernProst base model
   - `gbouras13/modernprost-profiles` - Newer ModernProst with profile support
+  - `Rostlab/ProstT5` - Original ProstT5 model
+  - `Rostlab/ProstT5_fp16` - Original ProstT5 model
 - `--device, -d`: Device for inference (auto/cuda/mps/cpu)
+- `--encoding-size, -e`: Total amino acids per encoding batch (default: 10000)
+- `--multi-gpu`: Use multi-GPU parallel encoding when available
+- `--gpu-ids`: Comma-separated GPU IDs to use with `--multi-gpu`
 - `--skip-entropy`: Skip entropy calculation
 
 ### `genome_entropy orf` - Find ORFs
@@ -318,10 +323,14 @@ Convert proteins to 3Di structural tokens using ProstT5 or ModernProst:
 genome_entropy encode3di \
     --input proteins.json \
     --output 3di.json \
-    --model Rostlab/ProstT5_fp16 \
+    --model gbouras13/modernprost-base \
     --device auto \
-    --batch-size 4
+    --encoding-size 10000
 ```
+
+`encode3di` accepts protein JSON from `translate` or `fasta-to-protein`, and can
+also read protein FASTA files (`.fasta`, `.fa`, `.faa`) directly. Add
+`--multi-gpu` and optional `--gpu-ids 0,1` to parallelize encoding across GPUs.
 
 ### `genome_entropy entropy` - Calculate Entropy
 
@@ -336,12 +345,41 @@ genome_entropy entropy --input 3di.json --output entropy.json --normalize
 Pre-download ProstT5 or ModernProst models to cache:
 
 ```bash
-# Download default ProstT5 model
-genome_entropy download --model Rostlab/ProstT5_fp16
+# Download default ModernProst model
+genome_entropy download
 
 # Download ModernProst models
 genome_entropy download --model gbouras13/modernprost-base
 genome_entropy download --model gbouras13/modernprost-profiles
+```
+
+### `genome_entropy estimate-tokens` - Estimate Encoding Size
+
+Estimate a practical encoding size for the selected model and device:
+
+```bash
+genome_entropy estimate-tokens --device cuda --model gbouras13/modernprost-base
+```
+
+### `genome_entropy ml` - GenBank Annotation Classifier
+
+Train and use classifiers that predict whether ORFs are annotated in GenBank:
+
+```bash
+# Train from pipeline JSON output
+genome_entropy ml train --json-dir results/ --output model.ubj
+
+# Train with a file-level 80/20 train/test split and detailed report
+genome_entropy ml train \
+    --split-dir results/ \
+    --output model.ubj \
+    --json-output detailed_results.json
+
+# Predict into a TSV file
+genome_entropy ml predict \
+    --json-dir new_results/ \
+    --model model.ubj \
+    --output predictions.tsv
 ```
 
 ## Logging
@@ -548,7 +586,7 @@ Contributions welcome! Please:
 - Install get_orfs and add to PATH or set GET_ORFS_PATH environment variable
 
 **CUDA out of memory**
-- Use CPU with `--device cpu` or reduce batch size with `--batch-size 1`
+- Use CPU with `--device cpu`, reduce `--encoding-size`, or use `--multi-gpu`
 
 **Model download fails**
 - Check internet connection

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,6 +16,7 @@ Core Modules
    genome_entropy.entropy
    genome_entropy.pipeline
    genome_entropy.io
+   genome_entropy.ml
 
 ORF Finding
 -----------
@@ -81,10 +82,42 @@ Encoder
    :undoc-members:
    :show-inheritance:
 
+ModernProst Encoder
+^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: genome_entropy.encode3di.modernprost
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+ProstT5 Encoder
+^^^^^^^^^^^^^^^
+
+.. automodule:: genome_entropy.encode3di.prostt5
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Encoding Functions
 ^^^^^^^^^^^^^^^^^^
 
 .. automodule:: genome_entropy.encode3di.encoding
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Multi-GPU Encoding
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: genome_entropy.encode3di.multi_gpu
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+GPU Utilities
+^^^^^^^^^^^^^
+
+.. automodule:: genome_entropy.encode3di.gpu_utils
    :members:
    :undoc-members:
    :show-inheritance:
@@ -153,6 +186,99 @@ JSON I/O
    :undoc-members:
    :show-inheritance:
 
+GenBank I/O
+^^^^^^^^^^^
+
+.. automodule:: genome_entropy.io.genbank
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Machine Learning
+----------------
+
+.. automodule:: genome_entropy.ml
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Classifier
+^^^^^^^^^^
+
+.. automodule:: genome_entropy.ml.classifier
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Models
+^^^^^^
+
+.. automodule:: genome_entropy.ml.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+File-Based Splitting
+^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: genome_entropy.ml.file_split
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+CLI Commands
+------------
+
+.. automodule:: genome_entropy.cli.main
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.run
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.orf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.translate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.fasta_to_protein
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.encode3di
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.entropy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.estimate_tokens
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.download
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: genome_entropy.cli.commands.ml
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Configuration
 -------------
 
@@ -185,13 +311,15 @@ ORF Finding
 
 .. code-block:: python
 
+   from genome_entropy.io.fasta import read_fasta
    from genome_entropy.orf.finder import find_orfs
 
-   # Find ORFs in a FASTA file
+   # Read DNA sequences and find ORFs
+   sequences = read_fasta("genome.fasta")
    orfs = find_orfs(
-       fasta_path="genome.fasta",
+       sequences=sequences,
        table_id=11,
-       min_length_nt=90
+       min_nt_length=90
    )
 
    # Examine results
@@ -219,11 +347,11 @@ Translation
 
 .. code-block:: python
 
-   from genome_entropy.encode3di import ProstT5ThreeDiEncoder
+   from genome_entropy.encode3di import ModernProstThreeDiEncoder
 
    # Initialize encoder
-   encoder = ProstT5ThreeDiEncoder(
-       model_name="Rostlab/ProstT5_fp16",
+   encoder = ModernProstThreeDiEncoder(
+       model_name="gbouras13/modernprost-base",
        device="auto"  # Auto-detect CUDA/MPS/CPU
    )
 
@@ -231,8 +359,7 @@ Translation
    aa_sequences = [p.aa_sequence for p in proteins]
    three_di_tokens = encoder.encode(
        aa_sequences,
-       batch_size=4,
-       encoding_size=5000
+       encoding_size=10000
    )
 
    for i, tokens in enumerate(three_di_tokens):
@@ -243,10 +370,10 @@ Token Estimation
 
 .. code-block:: python
 
-   from genome_entropy.encode3di import ProstT5ThreeDiEncoder, estimate_token_size
+   from genome_entropy.encode3di import ModernProstThreeDiEncoder, estimate_token_size
 
    # Initialize encoder
-   encoder = ProstT5ThreeDiEncoder()
+   encoder = ModernProstThreeDiEncoder()
 
    # Find optimal encoding size
    results = estimate_token_size(
@@ -258,12 +385,37 @@ Token Estimation
    )
 
    print(f"Recommended encoding size: {results['recommended_token_size']} AA")
-   
-   # Use in encoding
+
+   # Use the recommendation in encoding
    three_di = encoder.encode(
-       sequences,
-       encoding_size=results['recommended_token_size']
+       aa_sequences,
+       encoding_size=results["recommended_token_size"]
    )
+
+Machine Learning
+^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from genome_entropy.ml import GenbankClassifier, extract_features, load_json_data
+
+   # Load pipeline JSON files and extract ORF-level tabular features
+   json_data = load_json_data(Path("results"))
+   X, y, feature_names, metadata = extract_features(json_data, return_metadata=True)
+
+   # Train the default XGBoost classifier
+   classifier = GenbankClassifier(model_type="xgboost", device="cuda")
+   metrics = classifier.fit(X, y, feature_names=feature_names)
+   print(metrics)
+
+   # Save and reload the model
+   classifier.save(Path("genbank_classifier.ubj"))
+
+   loaded = GenbankClassifier(model_type="xgboost")
+   loaded.load(Path("genbank_classifier.ubj"))
+   predictions = loaded.predict(X)
 
 Shannon Entropy
 ^^^^^^^^^^^^^^^
@@ -304,7 +456,7 @@ Complete Pipeline
        output_json=Path("results.json"),
        table_id=11,
        min_aa_len=30,
-       model_name="Rostlab/ProstT5_fp16",
+       model_name="gbouras13/modernprost-base",
        device="auto",
        compute_entropy=True
    )
@@ -325,24 +477,24 @@ I/O Operations
 .. code-block:: python
 
    from genome_entropy.io.fasta import read_fasta, write_fasta
-   from genome_entropy.io.jsonio import save_json, load_json
+   from genome_entropy.io.jsonio import write_json, read_json
 
    # Read FASTA
    sequences = read_fasta("genome.fasta")
-   for seq_id, seq in sequences:
+   for seq_id, seq in sequences.items():
        print(f"{seq_id}: {len(seq)} bp")
 
    # Write FASTA
-   output_sequences = [
-       ("seq1", "ATCGATCG"),
-       ("seq2", "GCTAGCTA")
-   ]
-   write_fasta("output.fasta", output_sequences)
+   output_sequences = {
+       "seq1": "ATCGATCG",
+       "seq2": "GCTAGCTA",
+   }
+   write_fasta(output_sequences, "output.fasta")
 
    # Save/load JSON
    data = {"key": "value", "results": [1, 2, 3]}
-   save_json(data, "output.json")
-   loaded = load_json("output.json")
+   write_json(data, "output.json")
+   loaded = read_json("output.json")
 
 Error Handling
 ^^^^^^^^^^^^^^
@@ -357,7 +509,7 @@ Error Handling
    )
 
    try:
-       orfs = find_orfs("genome.fasta", table_id=11)
+       orfs = find_orfs({"seq1": "ATGGCTTAATAG"}, table_id=11)
    except OrfFinderError as e:
        print(f"ORF finding failed: {e}")
    except OrfEntropyError as e:

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -48,12 +48,17 @@ Run the complete pipeline from DNA to 3Di with entropy analysis.
 **Required Options:**
 
 ``--input, -i PATH``
-   Input FASTA file with DNA sequences
+   Input FASTA file with DNA sequences. Required if ``--genbank`` is not provided.
 
 ``--output, -o PATH``
    Output JSON file for results
 
 **Optional Options:**
+
+``--genbank, -g PATH``
+   GenBank file with DNA sequences and CDS annotations. Can be used instead of
+   ``--input``, or together with ``--input`` to use FASTA sequences with GenBank
+   annotations.
 
 ``--table, -t INTEGER``
    NCBI genetic code table ID
@@ -66,24 +71,30 @@ Run the complete pipeline from DNA to 3Di with entropy analysis.
    Default: 30
 
 ``--model, -m TEXT``
-   ProstT5 model name from HuggingFace
+   3Di model name from HuggingFace
    
-   Default: Rostlab/ProstT5_fp16
+   Default: gbouras13/modernprost-base
+
+   Supported models include ``gbouras13/modernprost-base``,
+   ``gbouras13/modernprost-profiles``, ``Rostlab/ProstT5``, and
+   ``Rostlab/ProstT5_fp16``.
 
 ``--device, -d TEXT``
-   Device for inference (auto, cuda, mps, cpu)
+   Device for inference (auto, cuda, mps, cpu). Ignored when ``--multi-gpu`` is set.
    
    Default: auto
-
-``--batch-size INTEGER``
-   Batch size for encoding
-   
-   Default: 4
 
 ``--encoding-size INTEGER``
    Total sequence length per encoding batch (in amino acids)
    
-   Default: 5000
+   Default: 10000
+
+``--multi-gpu``
+   Use multi-GPU parallel encoding when available.
+
+``--gpu-ids TEXT``
+   Comma-separated GPU IDs to use with ``--multi-gpu`` (for example, ``0,1,2``).
+   If omitted, available GPUs are auto-discovered.
 
 ``--skip-entropy``
    Skip entropy calculation
@@ -101,11 +112,17 @@ Run the complete pipeline from DNA to 3Di with entropy analysis.
        --output results.json \
        --table 1 \
        --min-aa 50 \
-       --device cuda \
-       --batch-size 8
+       --device cuda
 
    # Skip entropy for faster processing
    genome_entropy run --input genome.fasta --output results.json --skip-entropy
+
+   # Use GenBank annotations and multi-GPU encoding
+   genome_entropy run \
+       --genbank annotations.gbk \
+       --output results.json \
+       --multi-gpu \
+       --gpu-ids 0,1
 
 orf
 ^^^
@@ -194,7 +211,7 @@ Translate ORFs to protein sequences.
 encode3di
 ^^^^^^^^^
 
-Encode protein sequences to 3Di structural tokens using ProstT5.
+Encode protein sequences to 3Di structural tokens using ModernProst or ProstT5.
 
 **Usage:**
 
@@ -205,7 +222,9 @@ Encode protein sequences to 3Di structural tokens using ProstT5.
 **Required Options:**
 
 ``--input, -i PATH``
-   Input JSON file with protein records
+   Input protein file. FASTA files (``.fasta``, ``.fa``, ``.faa``) are read as
+   amino acid sequences; other inputs are treated as protein JSON records from
+   ``translate`` or ``fasta-to-protein``.
 
 ``--output, -o PATH``
    Output JSON file with 3Di records
@@ -213,24 +232,30 @@ Encode protein sequences to 3Di structural tokens using ProstT5.
 **Optional Options:**
 
 ``--model, -m TEXT``
-   ProstT5 model name
+   3Di model name
    
-   Default: Rostlab/ProstT5_fp16
+   Default: gbouras13/modernprost-base
+
+   Supported models include ``gbouras13/modernprost-base``,
+   ``gbouras13/modernprost-profiles``, ``Rostlab/ProstT5``, and
+   ``Rostlab/ProstT5_fp16``.
 
 ``--device, -d TEXT``
-   Device for inference (auto, cuda, mps, cpu)
+   Device for inference (auto, cuda, mps, cpu). Ignored when ``--multi-gpu`` is set.
    
    Default: auto
-
-``--batch-size INTEGER``
-   Number of sequences per batch
-   
-   Default: 4
 
 ``--encoding-size INTEGER``
    Total amino acids per encoding batch
    
-   Default: 5000
+   Default: 10000
+
+``--multi-gpu``
+   Use multi-GPU parallel encoding when available.
+
+``--gpu-ids TEXT``
+   Comma-separated GPU IDs to use with ``--multi-gpu`` (for example, ``0,1,2``).
+   If omitted, available GPUs are auto-discovered.
 
 **Examples:**
 
@@ -244,14 +269,53 @@ Encode protein sequences to 3Di structural tokens using ProstT5.
        --input proteins.json \
        --output 3di.json \
        --device cuda \
-       --batch-size 8 \
        --encoding-size 10000
+
+   # Encode a protein FASTA directly
+   genome_entropy encode3di --input proteins.faa --output 3di.json
+
+   # Encode on multiple GPUs
+   genome_entropy encode3di \
+       --input proteins.json \
+       --output 3di.json \
+       --multi-gpu \
+       --gpu-ids 0,1
 
    # Force CPU usage
    genome_entropy encode3di \
        --input proteins.json \
        --output 3di.json \
        --device cpu
+
+fasta-to-protein
+^^^^^^^^^^^^^^^^
+
+Convert protein FASTA input to the protein JSON format used by ``encode3di``.
+
+This is useful when you already have amino acid sequences and want to bypass ORF
+finding and translation. Because the proteins are not derived from ORFs, the
+command creates minimal placeholder ORF metadata for compatibility with the
+pipeline JSON schema.
+
+**Usage:**
+
+.. code-block:: bash
+
+   genome_entropy fasta-to-protein [OPTIONS]
+
+**Required Options:**
+
+``--input, -i PATH``
+   Input protein FASTA file
+
+``--output, -o PATH``
+   Output JSON file with protein records
+
+**Examples:**
+
+.. code-block:: bash
+
+   genome_entropy fasta-to-protein --input proteins.faa --output proteins.json
 
 entropy
 ^^^^^^^
@@ -293,7 +357,7 @@ Calculate Shannon entropy at all representation levels.
 download
 ^^^^^^^^
 
-Pre-download ProstT5 models to cache.
+Pre-download ModernProst or ProstT5 models to the HuggingFace cache.
 
 **Usage:**
 
@@ -306,7 +370,11 @@ Pre-download ProstT5 models to cache.
 ``--model, -m TEXT``
    Model name to download
    
-   Default: Rostlab/ProstT5_fp16
+   Default: gbouras13/modernprost-base
+
+``--test-data``
+   Request test datasets. This option is currently a placeholder; use
+   ``examples/example_small.fasta`` for local testing.
 
 **Examples:**
 
@@ -337,9 +405,9 @@ Estimate optimal encoding size for your GPU.
    Default: auto
 
 ``--model, -m TEXT``
-   ProstT5 model name
+   3Di model name
    
-   Default: Rostlab/ProstT5_fp16
+   Default: gbouras13/modernprost-base
 
 ``--start INTEGER``
    Starting encoding size to test
@@ -361,6 +429,19 @@ Estimate optimal encoding size for your GPU.
    
    Default: 3
 
+``--base-length, -b INTEGER``
+   Approximate length of generated individual proteins in amino acids
+
+   Default: 100
+
+``--log-level, -l LEVEL``
+   Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+
+   Default: INFO
+
+``--log-file PATH``
+   Path to log file
+
 **Examples:**
 
 .. code-block:: bash
@@ -377,6 +458,149 @@ Estimate optimal encoding size for your GPU.
 
    # Test CPU limits
    genome_entropy estimate-tokens --device cpu
+
+ml
+^^
+
+Train and use machine learning classifiers that predict whether ORFs correspond
+to GenBank CDS annotations. The classifier consumes JSON files produced by the
+pipeline, extracts tabular ORF-level features such as entropy values, lengths,
+position, strand, frame, and start/stop codon flags, then trains either an
+XGBoost model or a PyTorch neural network.
+
+The ML dependencies are optional. Install them with:
+
+.. code-block:: bash
+
+   pip install "genome_entropy[ml]"
+
+ml train
+""""""""
+
+Train a classifier and save the model.
+
+**Usage:**
+
+.. code-block:: bash
+
+   genome_entropy ml train [OPTIONS]
+
+**Required Options:**
+
+Exactly one input source is required:
+
+``--json-dir, -i PATH``
+   Directory containing JSON output files from ``genome_entropy run``. Uses all
+   files with random sample-level validation and test splits.
+
+``--split-dir PATH``
+   Directory containing JSON output files to split 80/20 by file into training
+   and held-out test sets.
+
+``--output, -o PATH``
+   Path where the trained model will be saved.
+
+**Optional Options:**
+
+``--model-type, -m TEXT``
+   Model type: ``xgboost`` or ``neural_net``
+
+   Default: xgboost
+
+``--device, -d TEXT``
+   Training device: ``cuda``, ``cpu``, or auto-detect when omitted.
+
+``--validation-split, -v FLOAT``
+   Fraction of data used for validation during training.
+
+   Default: 0.2
+
+``--test-split, -t FLOAT``
+   Fraction of samples held out for final testing in ``--json-dir`` mode. Ignored
+   when ``--split-dir`` is used.
+
+   Default: 0.1
+
+``--json-output PATH``
+   Save a detailed JSON report in ``--split-dir`` mode, including file lists and
+   test metrics.
+
+``--random-seed INTEGER``
+   Random seed for reproducible file splits.
+
+   Default: 42
+
+**Examples:**
+
+.. code-block:: bash
+
+   # Train the recommended XGBoost classifier
+   genome_entropy ml train --json-dir results/ --output model.ubj
+
+   # File-based train/test split with detailed reporting
+   genome_entropy ml train \
+       --split-dir results/ \
+       --output model.ubj \
+       --json-output detailed_results.json
+
+   # Train a neural network on CUDA
+   genome_entropy ml train \
+       --json-dir results/ \
+       --output model.pt \
+       --model-type neural_net \
+       --device cuda
+
+ml predict
+""""""""""
+
+Load a trained classifier and write per-ORF predictions.
+
+**Usage:**
+
+.. code-block:: bash
+
+   genome_entropy ml predict [OPTIONS]
+
+**Required Options:**
+
+``--json-dir, -i PATH``
+   Directory containing JSON files to predict on.
+
+``--model, -m PATH``
+   Path to a trained model file.
+
+``--output, -o PATH``
+   Path to save predictions in TSV format.
+
+**Optional Options:**
+
+``--model-type, -t TEXT``
+   Model type: ``xgboost`` or ``neural_net``
+
+   Default: xgboost
+
+**Output Columns:**
+
+``orf_id``
+   ORF identifier.
+
+``predicted_label``
+   Predicted class, where ``1`` means in GenBank and ``0`` means not in GenBank.
+
+``prob_not_in_genbank`` / ``prob_in_genbank``
+   Class probabilities from the model.
+
+``in_genbank``
+   Actual label when present in the input metadata, otherwise ``NA``.
+
+**Examples:**
+
+.. code-block:: bash
+
+   genome_entropy ml predict \
+       --json-dir new_results/ \
+       --model model.ubj \
+       --output predictions.tsv
 
 Common Workflows
 ----------------
@@ -409,8 +633,7 @@ Step-by-Step Analysis
    genome_entropy encode3di \
        --input proteins.json \
        --output 3di.json \
-       --device cuda \
-       --batch-size 8
+       --device cuda
 
    # Step 4: Calculate entropy
    genome_entropy entropy --input 3di.json --output entropy.json --normalize
@@ -429,6 +652,30 @@ Optimizing Performance
        --output results.json \
        --device cuda \
        --encoding-size 15000  # Use recommended value from estimate-tokens
+
+Protein FASTA to 3Di
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   # Convert first, then encode
+   genome_entropy fasta-to-protein --input proteins.faa --output proteins.json
+   genome_entropy encode3di --input proteins.json --output 3di.json
+
+   # Or encode the FASTA directly
+   genome_entropy encode3di --input proteins.faa --output 3di.json
+
+Training GenBank Annotation Classifiers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   genome_entropy run --genbank genome.gbk --output annotated_results.json
+   genome_entropy ml train --json-dir results/ --output genbank_classifier.ubj
+   genome_entropy ml predict \
+       --json-dir new_results/ \
+       --model genbank_classifier.ubj \
+       --output predictions.tsv
 
 Exit Codes
 ----------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -670,7 +670,9 @@ Training GenBank Annotation Classifiers
 
 .. code-block:: bash
 
-   genome_entropy run --genbank genome.gbk --output annotated_results.json
+   # Store annotated pipeline output in the directory used for training.
+   mkdir -p results
+   genome_entropy run --genbank genome.gbk --output results/annotated_results.json
    genome_entropy ml train --json-dir results/ --output genbank_classifier.ubj
    genome_entropy ml predict \
        --json-dir new_results/ \

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,9 +22,10 @@ Overview
 
 * Extract Open Reading Frames (ORFs) from DNA sequences
 * Translate ORFs to protein sequences using customizable genetic codes
-* Predict structural alphabet tokens (3Di) directly from sequences using ProstT5
+* Predict structural alphabet tokens (3Di) directly from sequences using ModernProst or ProstT5
 * Calculate and compare Shannon entropy at DNA, ORF, protein, and 3Di levels
-* Process data efficiently with GPU acceleration (CUDA, MPS, or CPU)
+* Train ML classifiers that predict GenBank annotations from ORF-level features
+* Process data efficiently with GPU acceleration (CUDA, MPS, CPU, or multiple GPUs)
 
 Key Features
 ------------
@@ -36,13 +37,19 @@ Key Features
    Convert ORFs to protein sequences with support for all NCBI genetic code tables
 
 🏗️ **3Di Encoding**
-   Predict structural alphabet tokens directly from sequences using ProstT5
+   Predict structural alphabet tokens directly from sequences using ModernProst or ProstT5
 
 📊 **Entropy Analysis**
    Calculate Shannon entropy at DNA, ORF, protein, and 3Di levels
 
+🤖 **ML Classifier**
+   Train XGBoost or neural-network models to predict GenBank annotations
+
 ⚡ **GPU Acceleration**
-   Auto-detect and use CUDA, MPS (Apple Silicon), or CPU
+   Auto-detect and use CUDA, MPS (Apple Silicon), CPU, or multiple GPUs
+
+🚀 **Multi-GPU Support**
+   Parallelize 3Di encoding across available GPUs
 
 🔧 **Modular CLI**
    Run complete pipeline or individual steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ docs = [
     "sphinx-rtd-theme>=2.0.0",
     "myst-parser>=2.0.0",
     "linkify-it-py>=2.0.0",
+    "numpy>=1.24.0",
+    "scikit-learn>=1.3.0",
+    "xgboost>=2.0.0",
 ]
 ml = [
     "xgboost>=2.0.0",


### PR DESCRIPTION
## Summary

- document the missing `genome_entropy ml` CLI surface, including `ml train` and `ml predict`
- refresh CLI docs for current ModernProst defaults, GenBank input, protein FASTA input, `fasta-to-protein`, `estimate-tokens`, and multi-GPU options
- expand API docs to include ML, GenBank I/O, ModernProst, ProstT5, multi-GPU, GPU utilities, and CLI command modules
- update README and docs index so public documentation matches current package capabilities

## Validation

- `git diff --check HEAD~1..HEAD`
- `python -m compileall -q src/genome_entropy`

## Notes

Sphinx HTML build was not run because `sphinx` is not installed in this environment.