### PR TITLE
adding usernames and projects

### DIFF
--- a/slurm/rocm/download.slurm
+++ b/slurm/rocm/download.slurm
@@ -11,7 +11,7 @@
 set -euo pipefail
 trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/genome_entropy"
+VENV_DIR="/scratch/$PAWSEY_PROJECT/$USER/software/pip/genome_entropy"
 if [[ ! -e "$VENV_DIR" ]]; then 
 	echo "Please run the installer to create the venv" >&2;
 	exit 1;

--- a/slurm/rocm/estimate_tokens.slurm
+++ b/slurm/rocm/estimate_tokens.slurm
@@ -11,7 +11,7 @@
 set -euo pipefail
 trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/genome_entropy"
+VENV_DIR="/scratch/$PAWSEY_PROJECT/$USER/software/pip/genome_entropy"
 if [[ ! -e "$VENV_DIR" ]]; then 
 	echo "Please run the installer to create the venv" >&2;
 	exit 1;

--- a/slurm/rocm/install.slurm
+++ b/slurm/rocm/install.slurm
@@ -16,10 +16,11 @@ trap 's=$?; echo "$0: Error on line $LINENO: $BASH_COMMAND"; exit $s' ERR
 # The project pkgs are in the pyproject.toml
 # ------------------------
 ROCM_MODULE_DEFAULT="rocm/6.4.1"
-VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/genome_entropy"
+VENV_DIR="/scratch/$PAWSEY_PROJECT/$USER/software/pip/genome_entropy"
 PROJECT_PKGS=(
   genome_entropy
   "transformers>=4.30.0"
+  "accelerate>=0.20.0"
   "pygenetic_code>=0.20.0"
   "typer>=0.9.0"
   "tqdm>=4.65.0"

--- a/slurm/rocm/pipeline.slurm
+++ b/slurm/rocm/pipeline.slurm
@@ -13,7 +13,7 @@ trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 
 
-VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/genome_entropy"
+VENV_DIR="/scratch/$PAWSEY_PROJECT/$USER/software/pip/genome_entropy"
 if [[ ! -e "$VENV_DIR" ]]; then 
 	echo "Please run the installer to create the venv" >&2;
 	exit 1;


### PR DESCRIPTION
This pull request updates the way the virtual environment directory is defined in several Slurm scripts to make the scripts more portable across different users and projects. It also adds a new package requirement to the installation script.

Environment variable improvements:

* Updated the `VENV_DIR` path in `download.slurm`, `estimate_tokens.slurm`, `install.slurm`, and `pipeline.slurm` to use `$PAWSEY_PROJECT` and `$USER` environment variables instead of hardcoded values, making the scripts reusable for different users and projects. [[1]](diffhunk://#diff-3db9093005f90aad1f618c97bb247812e7546802dfc12a8808a1807911bfc9e4L14-R14) [[2]](diffhunk://#diff-10c04fb99ce355ad75e45955e433e26c0730704ca8a2320606269c10246d5847L14-R14) [[3]](diffhunk://#diff-328324b9d5ed9c5604c1205858761497681e475c92a4b05c51aa66fc1b46e15cL19-R23) [[4]](diffhunk://#diff-17400c792b944dba40c45ec1b7437de627d68394482bc323920c887321a9612cL16-R16)

Dependency management:

* Added the `"accelerate>=0.20.0"` package to the `PROJECT_PKGS` list in `install.slurm` to ensure this dependency is installed in the virtual environment.