### PR TITLE
updating so that mismatch sequences is not fatal

### DIFF
--- a/slurm/rocm/pipeline.slurm
+++ b/slurm/rocm/pipeline.slurm
@@ -25,13 +25,13 @@ ENCSZ=20000
 
 if [[ $# -eq 2 ]]; then
 	echo "Running: genome_entropy run -g $1 -o $2 --multi-gpu" >&2;
-	genome_entropy run -g $1 -o $2 --multi-gpu --encoding-size $ENCSZ
+	genome_entropy --log-file $SLURM_JOB_ID.log run -g $1 -o $2 --multi-gpu --encoding-size $ENCSZ
 	exit 0
 fi
 
 if [[ $# -eq 3 ]]; then
 	echo "Running: genome_entropy run -i $1 -g $2 -o $3 --multi-gpu" >&2;
-	genome_entropy run -i $1 -g $2 -o $3 --multi-gpu --encoding-size $ENCSZ
+	genome_entropy --log-file $SLURM_JOB_ID.log run -i $1 -g $2 -o $3 --multi-gpu --encoding-size $ENCSZ
 	exit 0
 fi
 

--- a/src/genome_entropy/translate/translator.py
+++ b/src/genome_entropy/translate/translator.py
@@ -68,7 +68,7 @@ def translate_orf(
         aa_sequence = PyGeneticCode.translate(orf.nt_sequence, table_id)
 
         if aa_sequence != orf.aa_sequence:
-            errmsg = f"""
+            warning_message = f"""
             Translated amino acid sequence is not the same as read from the file:
             Provided:
             {orf.aa_sequence}
@@ -79,8 +79,11 @@ def translate_orf(
             Location:
             Start: {orf.start} Stop: {orf.end} Frame: {orf.frame} Strand: {orf.strand}
             """
-            logger.error("Translation mismatch for ORF %s", orf.orf_id)
-            raise ValueError(errmsg)
+            logger.warning(
+                "Translation mismatch for ORF %s; using translated sequence.%s",
+                orf.orf_id,
+                warning_message,
+            )
 
         # Remove stop codon (*) if present at the end
         if aa_sequence.endswith("*"):

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,9 +1,11 @@
 """Tests for translation functionality."""
 
+import logging
+
 import pytest
 
 from genome_entropy.orf.types import OrfRecord
-from genome_entropy.translate.translator import ProteinRecord
+from genome_entropy.translate.translator import ProteinRecord, translate_orf
 
 
 def test_protein_record_creation() -> None:
@@ -161,3 +163,30 @@ def test_protein_record_ambiguous_codons() -> None:
 
     assert "X" in protein.aa_sequence
     assert protein.aa_length == 4
+
+
+def test_translate_orf_warns_and_uses_translation_on_mismatch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A supplied protein mismatch is reported without stopping translation."""
+    orf = OrfRecord(
+        parent_id="seq1",
+        orf_id="orf1",
+        start=0,
+        end=9,
+        strand="+",
+        frame=0,
+        nt_sequence="ATGGCATAG",
+        aa_sequence="MV*",
+        table_id=11,
+        has_start_codon=True,
+        has_stop_codon=True,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        protein = translate_orf(orf, table_id=11)
+
+    assert protein.aa_sequence == "MA"
+    assert protein.aa_length == 2
+    assert "Translation mismatch for ORF orf1" in caplog.text
+    assert "using translated sequence" in caplog.text


### PR DESCRIPTION
This pull request updates the translation pipeline to improve error handling and logging, and adds a new test to verify the updated behavior. The most important changes are:

**Translation error handling and logging:**

* Changed the behavior in `translate_orf` (in `translator.py`) so that when a mismatch occurs between the provided and translated amino acid sequences, the function logs a warning and continues using the translated sequence instead of raising an error and stopping execution. [[1]](diffhunk://#diff-91ab78d044e9cd7e69f38a4f37804aa9a7b3b3aa1556c4bfe33c2fe6f77b7459L71-R71) [[2]](diffhunk://#diff-91ab78d044e9cd7e69f38a4f37804aa9a7b3b3aa1556c4bfe33c2fe6f77b7459L82-R86)

**Testing improvements:**

* Added a new test `test_translate_orf_warns_and_uses_translation_on_mismatch` in `test_translation.py` to ensure that a warning is logged and translation proceeds when there is a mismatch, rather than raising an exception.
* Updated imports in `test_translation.py` to include the necessary modules for the new test.

**Pipeline logging:**

* Updated the `pipeline.slurm` script to add logging of genome_entropy runs by specifying a log file named after the SLURM job ID.