### PR TITLE
Handle translation mismatches and multi-record ML JSON input

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,18 +171,25 @@ pip install "genome_entropy[ml]"
 # Standard mode: Train classifier on JSON output from GenBank files
 genome_entropy ml train --json-dir results/ --output model.ubj
 
+# Single-file mode: Split top-level records while keeping their ORFs together
+genome_entropy ml train --json results.json --output model.ubj
+
 # File-based split mode: Randomly split files 80/20 for train/test
 genome_entropy ml train --split-dir results/ --output model.ubj \
     --json-output detailed_results.json
 
 # Make predictions on new data
 genome_entropy ml predict --json-dir new_results/ --model model.ubj --output predictions.tsv
+
+# Predict every ORF in a multi-record JSON file
+genome_entropy ml predict --json results.json --model model.ubj --output predictions.tsv
 ```
 
-**Two modes of operation:**
+**Three modes of operation:**
 
-1. **Standard mode** (`--json-dir`): Uses all files in directory with random sample-level train/test split (default 90/10)
-2. **File-based split mode** (`--split-dir`): Randomly splits files 80/20 into training and test sets, trains on training files, evaluates on test files. Outputs detailed JSON report with file lists, training parameters, and per-prediction results.
+1. **Single-file mode** (`--json`): Splits top-level records into training and test sets (default 90/10), keeping all ORFs from each record together.
+2. **Standard mode** (`--json-dir`): Uses all files in directory with random sample-level train/test split (default 90/10).
+3. **File-based split mode** (`--split-dir`): Randomly splits files 80/20 into training and test sets, trains on training files, evaluates on test files. Outputs detailed JSON report with file lists, training parameters, and per-prediction results.
 
 The ML classifier uses **XGBoost (Gradient Boosted Trees)** by default, which is recommended for this task because:
 
@@ -369,6 +376,9 @@ Train and use classifiers that predict whether ORFs are annotated in GenBank:
 # Train from pipeline JSON output
 genome_entropy ml train --json-dir results/ --output model.ubj
 
+# Train from one multi-record pipeline JSON
+genome_entropy ml train --json results.json --output model.ubj
+
 # Train with a file-level 80/20 train/test split and detailed report
 genome_entropy ml train \
     --split-dir results/ \
@@ -378,6 +388,12 @@ genome_entropy ml train \
 # Predict into a TSV file
 genome_entropy ml predict \
     --json-dir new_results/ \
+    --model model.ubj \
+    --output predictions.tsv
+
+# Predict every ORF from one multi-record pipeline JSON
+genome_entropy ml predict \
+    --json results.json \
     --model model.ubj \
     --output predictions.tsv
 ```

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -489,6 +489,10 @@ Train a classifier and save the model.
 
 Exactly one input source is required:
 
+``--json PATH``
+   One JSON file containing multiple pipeline records. Records are split between
+   training and test sets while all ORFs from a record remain together.
+
 ``--json-dir, -i PATH``
    Directory containing JSON output files from ``genome_entropy run``. Uses all
    files with random sample-level validation and test splits.
@@ -516,8 +520,9 @@ Exactly one input source is required:
    Default: 0.2
 
 ``--test-split, -t FLOAT``
-   Fraction of samples held out for final testing in ``--json-dir`` mode. Ignored
-   when ``--split-dir`` is used.
+   Fraction held out for final testing. In ``--json`` mode this is the fraction
+   of top-level records; in ``--json-dir`` mode it is the fraction of ORFs.
+   Ignored when ``--split-dir`` is used.
 
    Default: 0.1
 
@@ -536,6 +541,9 @@ Exactly one input source is required:
 
    # Train the recommended XGBoost classifier
    genome_entropy ml train --json-dir results/ --output model.ubj
+
+   # Train from one multi-record JSON without record-level leakage
+   genome_entropy ml train --json results.json --output model.ubj
 
    # File-based train/test split with detailed reporting
    genome_entropy ml train \
@@ -563,6 +571,11 @@ Load a trained classifier and write per-ORF predictions.
 
 **Required Options:**
 
+Exactly one input source is required:
+
+``--json PATH``
+   One JSON file containing one or more pipeline records.
+
 ``--json-dir, -i PATH``
    Directory containing JSON files to predict on.
 
@@ -580,6 +593,9 @@ Load a trained classifier and write per-ORF predictions.
    Default: xgboost
 
 **Output Columns:**
+
+``input_id``
+   Identifier of the top-level input record.
 
 ``orf_id``
    ORF identifier.
@@ -599,6 +615,11 @@ Load a trained classifier and write per-ORF predictions.
 
    genome_entropy ml predict \
        --json-dir new_results/ \
+       --model model.ubj \
+       --output predictions.tsv
+
+   genome_entropy ml predict \
+       --json results.json \
        --model model.ubj \
        --output predictions.tsv
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -181,6 +181,7 @@ Tips for Large Datasets
 3. **Filter short ORFs**: Use ``--min-aa`` to exclude short proteins
 4. **Log to file**: Use ``--log-file`` to track progress
 5. **Estimate tokens first**: Use ``estimate-tokens`` to find optimal encoding size
+6. **Combine all the sequences into one file**: Use a single FASTA file or GenBank for all sequences because we only need to load the model onto the GPU once, and then reuse it for all sequences. This is much faster than loading the model for each sequence.
 
 Example Workflow
 ----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "genome_entropy"
-version = "0.1.11"
+version = "0.1.12"
 description = "Quantify information content across multiple biological representations derived from genomic sequences"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/genome_entropy/cli/commands/ml.py
+++ b/src/genome_entropy/cli/commands/ml.py
@@ -9,6 +9,7 @@ from ...logging_config import get_logger
 from ...ml.classifier import (
     GenbankClassifier,
     extract_features,
+    filter_json_records_with_features,
     load_json_data,
     load_json_file,
     split_json_records,
@@ -232,10 +233,12 @@ def train_classifier(
             logger.info("\nSINGLE-FILE MODE: Using record-level split")
             logger.info(f"\nLoading JSON records from: {json_file}")
             json_data = load_json_file(json_file)
+            json_data = filter_json_records_with_features(json_data)
             if len(json_data) < 2:
                 raise ValueError(
                     "Training with --json requires at least 2 top-level records "
-                    "so both training and test sets are non-empty"
+                    "containing usable ORFs so both training and test sets are "
+                    "non-empty"
                 )
         else:
             logger.info("\nSTANDARD MODE: Using all files with sample-level split")

--- a/src/genome_entropy/cli/commands/ml.py
+++ b/src/genome_entropy/cli/commands/ml.py
@@ -6,7 +6,13 @@ from typing import Optional
 import typer
 
 from ...logging_config import get_logger
-from ...ml.classifier import GenbankClassifier, load_json_data, extract_features
+from ...ml.classifier import (
+    GenbankClassifier,
+    extract_features,
+    load_json_data,
+    load_json_file,
+    split_json_records,
+)
 
 logger = get_logger(__name__)
 
@@ -15,6 +21,11 @@ app = typer.Typer(help="Train ML classifier to predict GenBank annotations")
 
 @app.command("train")
 def train_classifier(
+    json_file: Optional[Path] = typer.Option(
+        None,
+        "--json",
+        help="Single JSON file containing multiple pipeline records",
+    ),
     json_dir: Optional[Path] = typer.Option(
         None,
         "--json-dir",
@@ -65,13 +76,16 @@ def train_classifier(
     original GenBank file (in_genbank: True/False) based on sequence features
     including entropy values, length, position, and other characteristics.
     
-    TWO MODES OF OPERATION:
+    THREE MODES OF OPERATION:
     -----------------------
     
-    1. **Standard mode** (--json-dir): Uses all files in directory with random
+    1. **Single-file mode** (--json): Splits top-level records into training and
+       test sets while keeping all ORFs from each record together.
+
+    2. **Standard mode** (--json-dir): Uses all files in directory with random
        sample-level train/test split.
        
-    2. **File-based split mode** (--split-dir): Randomly splits files 80/20 into
+    3. **File-based split mode** (--split-dir): Randomly splits files 80/20 into
        training and test sets, trains on training files, evaluates on test files.
        Outputs detailed JSON report with file lists and results.
     
@@ -117,6 +131,9 @@ def train_classifier(
     
     Basic usage with XGBoost (recommended):
         genome_entropy ml train --json-dir results/ --output model.ubj
+
+    Train from one multi-record JSON file:
+        genome_entropy ml train --json results.json --output model.ubj
     
     File-based train/test split with detailed JSON report:
         genome_entropy ml train --split-dir results/ --output model.ubj \\
@@ -134,19 +151,26 @@ def train_classifier(
     logger.info("GenBank ORF Classification - Model Training")
     logger.info("=" * 60)
 
-    # Validate inputs - exactly one of json_dir or split_dir must be provided
-    if json_dir is None and split_dir is None:
-        logger.error("Either --json-dir or --split-dir must be provided")
+    # Validate inputs - exactly one input mode must be provided
+    inputs = [json_file, json_dir, split_dir]
+    if sum(value is not None for value in inputs) != 1:
+        logger.error(
+            "Exactly one of --json, --json-dir, or --split-dir must be provided"
+        )
         raise typer.Exit(1)
 
-    if json_dir is not None and split_dir is not None:
-        logger.error("Cannot use both --json-dir and --split-dir. Choose one mode.")
+    if not 0 < test_split < 1:
+        logger.error("--test-split must be between 0 and 1")
         raise typer.Exit(1)
 
-    # Validate directories exist
-    input_dir = json_dir if json_dir is not None else split_dir
-    if not input_dir.is_dir():
-        logger.error(f"Directory not found: {input_dir}")
+    # Validate the selected input path
+    input_path = json_file or json_dir or split_dir
+    path_is_valid = (
+        input_path.is_file() if json_file is not None else input_path.is_dir()
+    )
+    if not path_is_valid:
+        expected = "file" if json_file is not None else "directory"
+        logger.error(f"Input {expected} not found: {input_path}")
         raise typer.Exit(1)
 
     if model_type not in ["xgboost", "neural_net"]:
@@ -202,23 +226,56 @@ def train_classifier(
 
         return
 
-    # Original logic for standard mode (--json-dir)
-    logger.info("\nSTANDARD MODE: Using all files with sample-level split")
-
-    # Load data
-    logger.info(f"\nLoading JSON files from: {json_dir}")
+    # Load data for standard directory mode or record-aware single-file mode
     try:
-        json_data = load_json_data(json_dir)
+        if json_file is not None:
+            logger.info("\nSINGLE-FILE MODE: Using record-level split")
+            logger.info(f"\nLoading JSON records from: {json_file}")
+            json_data = load_json_file(json_file)
+            if len(json_data) < 2:
+                raise ValueError(
+                    "Training with --json requires at least 2 top-level records "
+                    "so both training and test sets are non-empty"
+                )
+        else:
+            logger.info("\nSTANDARD MODE: Using all files with sample-level split")
+            logger.info(f"\nLoading JSON files from: {json_dir}")
+            json_data = load_json_data(json_dir)
     except Exception as e:
         logger.error(f"Failed to load JSON data: {e}")
         raise typer.Exit(1)
 
-    # Extract features
-    logger.info("\nExtracting features from JSON data...")
+    import numpy as np
+
+    # Split a multi-record file by record, keeping all ORFs belonging to one
+    # genome/sequence together. Directory mode retains its sample-level split.
     try:
-        X, y, feature_names, _ = extract_features(json_data)
+        if json_file is not None:
+            train_data, test_data = split_json_records(
+                json_data, test_split=test_split, random_seed=random_seed
+            )
+
+            X_trainval, y_trainval, feature_names, _ = extract_features(train_data)
+            X_test, y_test, _, _ = extract_features(test_data)
+            X = np.concatenate((X_trainval, X_test))
+            y = np.concatenate((y_trainval, y_test))
+            logger.info(
+                f"Record split: {len(train_data)} train+val records, "
+                f"{len(test_data)} test records"
+            )
+        else:
+            X, y, feature_names, _ = extract_features(json_data)
+            n_samples = len(X)
+            n_test = int(n_samples * test_split)
+            n_test = max(1, min(n_test, n_samples - 1))
+            rng = np.random.default_rng(random_seed)
+            indices = rng.permutation(n_samples)
+            X_trainval = X[indices[n_test:]]
+            y_trainval = y[indices[n_test:]]
+            X_test = X[indices[:n_test]]
+            y_test = y[indices[:n_test]]
     except Exception as e:
-        logger.error(f"Failed to extract features: {e}")
+        logger.error(f"Failed to extract or split features: {e}")
         raise typer.Exit(1)
 
     logger.info(f"Extracted {len(X)} ORF samples with {len(feature_names)} features")
@@ -232,18 +289,6 @@ def train_classifier(
     if pos_ratio < 0.1 or pos_ratio > 0.9:
         logger.warning(f"Class imbalance detected: {pos_ratio:.1%} positive samples")
         logger.warning("Model may have difficulty with minority class")
-
-    # Split data into train+val and test sets
-    import numpy as np
-
-    n_samples = len(X)
-    n_test = int(n_samples * test_split)
-    indices = np.random.permutation(n_samples)
-
-    X_trainval = X[indices[n_test:]]
-    y_trainval = y[indices[n_test:]]
-    X_test = X[indices[:n_test]]
-    y_test = y[indices[:n_test]]
 
     logger.info(f"\nData split: {len(X_trainval)} train+val, {len(X_test)} test")
 
@@ -322,8 +367,11 @@ def train_classifier(
 
 @app.command("predict")
 def predict_with_classifier(
-    json_dir: Path = typer.Option(
-        ..., "--json-dir", "-i", help="Directory containing JSON files to predict on"
+    json_file: Optional[Path] = typer.Option(
+        None, "--json", help="Single JSON file containing records to predict"
+    ),
+    json_dir: Optional[Path] = typer.Option(
+        None, "--json-dir", "-i", help="Directory containing JSON files to predict"
     ),
     model: Path = typer.Option(..., "--model", "-m", help="Path to trained model file"),
     output: Path = typer.Option(
@@ -335,13 +383,21 @@ def predict_with_classifier(
 ) -> None:
     """Make predictions using a trained classifier.
 
-    Loads a previously trained model and makes predictions on new JSON files.
-    Outputs predictions in TSV format with ORF IDs, predicted labels, probabilities,
-    and actual in_genbank values (if available).
+    Loads a previously trained model and makes predictions on a multi-record JSON
+    file or a directory of JSON files. Outputs every ORF in TSV format with input
+    IDs, ORF IDs, predicted labels, probabilities, and actual in_genbank values.
     """
-    logger.info("Loading JSON files...")
+    if (json_file is None) == (json_dir is None):
+        logger.error("Exactly one of --json or --json-dir must be provided")
+        raise typer.Exit(1)
+
+    logger.info("Loading JSON data...")
     try:
-        json_data = load_json_data(json_dir)
+        json_data = (
+            load_json_file(json_file)
+            if json_file is not None
+            else load_json_data(json_dir)
+        )
     except Exception as e:
         logger.error(f"Failed to load JSON data: {e}")
         raise typer.Exit(1)
@@ -375,15 +431,20 @@ def predict_with_classifier(
     with open(output, "w") as f:
         # Write header
         f.write(
-            "orf_id\tpredicted_label\tprob_not_in_genbank\tprob_in_genbank\tin_genbank\n"
+            "input_id\torf_id\tpredicted_label\tprob_not_in_genbank\t"
+            "prob_in_genbank\tin_genbank\n"
         )
 
         # Write predictions
         for i, (pred, prob) in enumerate(zip(predictions, probabilities)):
             orf_id = metadata[i]["orf_id"] if metadata else f"orf_{i}"
+            input_id = metadata[i]["input_id"] if metadata else ""
             actual_label = metadata[i]["in_genbank"] if metadata else "NA"
 
-            f.write(f"{orf_id}\t{pred}\t{prob[0]:.6f}\t{prob[1]:.6f}\t{actual_label}\n")
+            f.write(
+                f"{input_id}\t{orf_id}\t{pred}\t{prob[0]:.6f}\t"
+                f"{prob[1]:.6f}\t{actual_label}\n"
+            )
 
     logger.info(f"Predictions saved. {len(predictions)} samples processed.")
     logger.info(f"Predicted in GenBank: {(predictions == 1).sum()}")

--- a/src/genome_entropy/ml/__init__.py
+++ b/src/genome_entropy/ml/__init__.py
@@ -1,11 +1,19 @@
 """Machine learning module for predicting GenBank annotations."""
 
-from .classifier import GenbankClassifier, load_json_data, extract_features
+from .classifier import (
+    GenbankClassifier,
+    extract_features,
+    load_json_data,
+    load_json_file,
+    split_json_records,
+)
 from .models import XGBoostModel, NeuralNetModel
 
 __all__ = [
     "GenbankClassifier",
     "load_json_data",
+    "load_json_file",
+    "split_json_records",
     "extract_features",
     "XGBoostModel",
     "NeuralNetModel",

--- a/src/genome_entropy/ml/__init__.py
+++ b/src/genome_entropy/ml/__init__.py
@@ -3,6 +3,7 @@
 from .classifier import (
     GenbankClassifier,
     extract_features,
+    filter_json_records_with_features,
     load_json_data,
     load_json_file,
     split_json_records,
@@ -15,6 +16,7 @@ __all__ = [
     "load_json_file",
     "split_json_records",
     "extract_features",
+    "filter_json_records_with_features",
     "XGBoostModel",
     "NeuralNetModel",
 ]

--- a/src/genome_entropy/ml/classifier.py
+++ b/src/genome_entropy/ml/classifier.py
@@ -314,6 +314,32 @@ def extract_features(
         return X, y, feature_names, None
 
 
+def filter_json_records_with_features(
+    json_data: List[List[Dict[str, Any]]],
+) -> List[List[Dict[str, Any]]]:
+    """Return only record groups containing at least one extractable ORF."""
+    usable_records = []
+    for record_group in json_data:
+        try:
+            extract_features([record_group])
+        except ValueError:
+            input_ids = [
+                str(record.get("input_id", "<unknown>")) for record in record_group
+            ]
+            logger.warning(
+                "Skipping record(s) with no usable ORFs: %s", ", ".join(input_ids)
+            )
+            continue
+        usable_records.append(record_group)
+
+    logger.info(
+        "Retained %d/%d record(s) containing usable ORFs",
+        len(usable_records),
+        len(json_data),
+    )
+    return usable_records
+
+
 class GenbankClassifier:
     """Machine learning classifier for predicting GenBank ORF annotations.
 

--- a/src/genome_entropy/ml/classifier.py
+++ b/src/genome_entropy/ml/classifier.py
@@ -48,6 +48,12 @@ def load_json_data(json_dir: Path) -> List[List[Dict[str, Any]]]:
     for json_file in json_files:
         try:
             content = read_json(json_file)
+            if isinstance(content, dict):
+                content = [content]
+            if not isinstance(content, list) or not all(
+                isinstance(record, dict) for record in content
+            ):
+                raise ValueError("top level must be a JSON object or list of objects")
             data.append(content)
             logger.debug(f"Loaded {json_file.name}")
         except json.JSONDecodeError as e:
@@ -62,6 +68,61 @@ def load_json_data(json_dir: Path) -> List[List[Dict[str, Any]]]:
 
     logger.info(f"Successfully loaded {len(data)} JSON files")
     return data
+
+
+def load_json_file(json_file: Path) -> List[List[Dict[str, Any]]]:
+    """Load records from one pipeline JSON file as independent groups.
+
+    Keeping each top-level record separate allows train/test splitting by
+    genome or sequence instead of mixing ORFs from one record across splits.
+    """
+    from ..io.jsonio import read_json
+
+    json_file = Path(json_file)
+    if not json_file.is_file():
+        raise ValueError(f"Not a file: {json_file}")
+
+    content = read_json(json_file)
+    if isinstance(content, dict):
+        records = [content]
+    elif isinstance(content, list):
+        records = content
+    else:
+        raise ValueError(
+            f"Expected a JSON object or list of records in {json_file}, "
+            f"got {type(content).__name__}"
+        )
+
+    if not records:
+        raise ValueError(f"No records found in {json_file}")
+    if not all(isinstance(record, dict) for record in records):
+        raise ValueError(f"All records in {json_file} must be JSON objects")
+
+    logger.info(f"Successfully loaded {len(records)} record(s) from {json_file}")
+    return [[record] for record in records]
+
+
+def split_json_records(
+    json_data: List[List[Dict[str, Any]]],
+    test_split: float = 0.1,
+    random_seed: int = 42,
+) -> Tuple[List[List[Dict[str, Any]]], List[List[Dict[str, Any]]]]:
+    """Split top-level JSON records into reproducible train and test groups."""
+    if not 0 < test_split < 1:
+        raise ValueError(f"test_split must be between 0 and 1, got {test_split}")
+    if len(json_data) < 2:
+        raise ValueError("Record splitting requires at least 2 top-level records")
+
+    rng = np.random.default_rng(random_seed)
+    indices = rng.permutation(len(json_data))
+    n_test = int(len(json_data) * test_split)
+    n_test = max(1, min(n_test, len(json_data) - 1))
+    test_indices = indices[:n_test]
+    train_indices = indices[n_test:]
+    return (
+        [json_data[i] for i in train_indices],
+        [json_data[i] for i in test_indices],
+    )
 
 
 def extract_features(
@@ -152,6 +213,7 @@ def extract_features(
                         if return_metadata:
                             metadata_list.append(
                                 {
+                                    "input_id": data.get("input_id", ""),
                                     "orf_id": orf_id,
                                     "in_genbank": feature["metadata"]["in_genbank"],
                                 }
@@ -217,6 +279,7 @@ def extract_features(
                         if return_metadata:
                             metadata_list.append(
                                 {
+                                    "input_id": data.get("input_id", ""),
                                     "orf_id": orf_id,
                                     "in_genbank": orf.get("in_genbank", False),
                                 }

--- a/src/genome_entropy/ml/file_split.py
+++ b/src/genome_entropy/ml/file_split.py
@@ -101,6 +101,12 @@ def load_json_files(file_list: List[Path]) -> List[List[Dict[str, Any]]]:
     for json_file in file_list:
         try:
             content = read_json(json_file)
+            if isinstance(content, dict):
+                content = [content]
+            if not isinstance(content, list) or not all(
+                isinstance(record, dict) for record in content
+            ):
+                raise ValueError("top level must be a JSON object or list of objects")
             data.append(content)
             logger.debug(f"Loaded {json_file.name}")
         except json.JSONDecodeError as e:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -159,3 +159,36 @@ def test_fasta_to_protein_command_help() -> None:
     assert "input" in result.stdout.lower()
     assert "output" in result.stdout.lower()
     assert "fasta" in result.stdout.lower() or "protein" in result.stdout.lower()
+
+
+def test_ml_commands_expose_single_json_input() -> None:
+    """Both ML workflows advertise the single multi-record JSON option."""
+    for subcommand in ("train", "predict"):
+        result = runner.invoke(app, ["ml", subcommand, "--help"])
+        assert result.exit_code == 0
+        clean_output = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+        assert "--json" in clean_output
+        assert "--json-dir" in clean_output
+
+
+def test_ml_predict_rejects_json_and_json_dir_together(tmp_path) -> None:
+    """Single-file and directory prediction inputs are mutually exclusive."""
+    json_file = tmp_path / "records.json"
+    json_file.write_text("[]")
+    result = runner.invoke(
+        app,
+        [
+            "ml",
+            "predict",
+            "--json",
+            str(json_file),
+            "--json-dir",
+            str(tmp_path),
+            "--model",
+            str(tmp_path / "model.ubj"),
+            "--output",
+            str(tmp_path / "predictions.tsv"),
+        ],
+    )
+
+    assert result.exit_code == 1

--- a/tests/test_ml_classifier.py
+++ b/tests/test_ml_classifier.py
@@ -8,9 +8,11 @@ import pytest
 import numpy as np
 
 from genome_entropy.ml.classifier import (
-    load_json_data,
-    extract_features,
     GenbankClassifier,
+    extract_features,
+    load_json_data,
+    load_json_file,
+    split_json_records,
 )
 
 
@@ -114,6 +116,83 @@ def test_load_json_data_empty_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
         with pytest.raises(ValueError, match="No JSON files found"):
             load_json_data(Path(tmpdir))
+
+
+def test_load_multi_record_json_file(sample_json_unified, tmp_path):
+    """Each top-level record in one JSON file remains an independent group."""
+    records = []
+    for i in range(3):
+        record = json.loads(json.dumps(sample_json_unified[0]))
+        record["input_id"] = f"sequence_{i}"
+        records.append(record)
+
+    json_file = tmp_path / "combined.json"
+    json_file.write_text(json.dumps(records))
+
+    data = load_json_file(json_file)
+
+    assert len(data) == 3
+    assert [group[0]["input_id"] for group in data] == [
+        "sequence_0",
+        "sequence_1",
+        "sequence_2",
+    ]
+    assert all(len(group) == 1 for group in data)
+
+
+def test_split_multi_record_json_keeps_records_together(
+    sample_json_unified, tmp_path
+):
+    """Record-level splitting never divides one record's ORFs across sets."""
+    records = []
+    for i in range(10):
+        record = json.loads(json.dumps(sample_json_unified[0]))
+        record["input_id"] = f"sequence_{i}"
+        records.append(record)
+
+    json_file = tmp_path / "combined.json"
+    json_file.write_text(json.dumps(records))
+    data = load_json_file(json_file)
+
+    train_data, test_data = split_json_records(
+        data, test_split=0.2, random_seed=123
+    )
+    train_ids = {group[0]["input_id"] for group in train_data}
+    test_ids = {group[0]["input_id"] for group in test_data}
+
+    assert len(train_data) == 8
+    assert len(test_data) == 2
+    assert train_ids.isdisjoint(test_ids)
+    assert train_ids | test_ids == {f"sequence_{i}" for i in range(10)}
+
+
+def test_multi_record_file_extracts_all_orfs_and_input_ids(
+    sample_json_unified, tmp_path
+):
+    """Prediction inputs include every ORF with record-identifying metadata."""
+    records = []
+    for i in range(3):
+        record = json.loads(json.dumps(sample_json_unified[0]))
+        record["input_id"] = f"sequence_{i}"
+        records.append(record)
+
+    json_file = tmp_path / "combined.json"
+    json_file.write_text(json.dumps(records))
+
+    data = load_json_file(json_file)
+    X, y, _, metadata = extract_features(data, return_metadata=True)
+
+    assert X.shape[0] == 6
+    assert y.shape[0] == 6
+    assert metadata is not None
+    assert [item["input_id"] for item in metadata] == [
+        "sequence_0",
+        "sequence_0",
+        "sequence_1",
+        "sequence_1",
+        "sequence_2",
+        "sequence_2",
+    ]
 
 
 def test_extract_features_unified_format(sample_json_unified):

--- a/tests/test_ml_classifier.py
+++ b/tests/test_ml_classifier.py
@@ -10,6 +10,7 @@ import numpy as np
 from genome_entropy.ml.classifier import (
     GenbankClassifier,
     extract_features,
+    filter_json_records_with_features,
     load_json_data,
     load_json_file,
     split_json_records,
@@ -164,6 +165,38 @@ def test_split_multi_record_json_keeps_records_together(
     assert len(test_data) == 2
     assert train_ids.isdisjoint(test_ids)
     assert train_ids | test_ids == {f"sequence_{i}" for i in range(10)}
+
+
+def test_featureless_records_are_removed_before_record_split(
+    sample_json_unified, tmp_path
+):
+    """Empty pipeline results cannot become an unusable train or test set."""
+    usable_records = []
+    for i in range(2):
+        record = json.loads(json.dumps(sample_json_unified[0]))
+        record["input_id"] = f"usable_{i}"
+        usable_records.append(record)
+    empty_record = {
+        "schema_version": "2.0.0",
+        "input_id": "no_orfs",
+        "features": {},
+    }
+
+    json_file = tmp_path / "combined.json"
+    json_file.write_text(json.dumps([empty_record, *usable_records]))
+
+    data = filter_json_records_with_features(load_json_file(json_file))
+    train_data, test_data = split_json_records(
+        data, test_split=0.5, random_seed=42
+    )
+
+    assert len(data) == 2
+    assert len(train_data) == 1
+    assert len(test_data) == 1
+    assert {
+        train_data[0][0]["input_id"],
+        test_data[0][0]["input_id"],
+    } == {"usable_0", "usable_1"}
 
 
 def test_multi_record_file_extracts_all_orfs_and_input_ids(


### PR DESCRIPTION
## Summary

- report GenBank protein translation mismatches as warnings and continue with the computed translation
- bump the package version to 0.1.11 and add the related quickstart note
- add mutually exclusive `--json` and `--json-dir` inputs to `genome_entropy ml train` and `ml predict`
- split a single multi-record JSON file at the top-level record boundary so ORFs from one genome/sequence cannot leak across training and test sets
- predict every ORF in a multi-record file and include both `input_id` and `orf_id` in TSV output
- normalize single-object and list-based pipeline JSON inputs, including directory/file-split loaders
- document the new workflows and add regression coverage

## Why

HPC workflows are easier to manage with one consolidated JSON output than with directories containing many small files. Treating each top-level record as the split unit preserves biologically appropriate train/test isolation, while record-aware prediction keeps ORFs uniquely attributable when IDs repeat across genomes.

Protein annotations may also disagree with translations computed from ambiguous nucleotide sequences. Such mismatches should be visible but should not abort a large pipeline run; the computed translation is now retained and processing continues.

## Validation

- `venv/bin/pytest -q tests/test_ml_classifier.py tests/test_file_split.py tests/test_cli_smoke.py` — 36 passed, 5 skipped because optional XGBoost is not installed
- focused translation, GenBank, and ORF tests — 31 passed
- version and CLI tests — 18 passed
- Ruff checks passed for all changed Python files
- `git diff --check` passed

A full non-integration suite was started but stopped after it produced no output for roughly two minutes; the focused affected suites above completed successfully.