### PR TITLE
Add interactive XGBoost random forest notebook

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -6,7 +6,7 @@ _genome_entropy_. Start Jupyter from the repository environment so the local
 
 ```bash
 source venv/bin/activate
-pip install -e ".[ml]"
+pip install -e ".[ml]" jupyterlab pandas matplotlib
 jupyter lab notebooks/
 ```
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,5 +1,68 @@
-# Jupter Notebooks for Analysing Data
+# Jupyter Notebooks for Analysing Data
 
-These notebooks show you how to access and analyse the data from _genome_entropy_. 
+These notebooks show how to access, analyse, visualise, and model output from
+_genome_entropy_. Start Jupyter from the repository environment so the local
+`genome_entropy` package and optional analysis dependencies are importable:
 
-- [plot JSON](plot_json.ipynb) reads some fields from the JSON output into a pandas dataframe, and then creates an entropy scatter plot.
+```bash
+source venv/bin/activate
+pip install -e ".[ml]"
+jupyter lab notebooks/
+```
+
+## Available notebooks
+
+### [Plot JSON](plot_json.ipynb)
+
+Reads selected fields from pipeline JSON output into a pandas DataFrame and
+creates an entropy scatter plot. This is a compact introduction to exploring
+the unified output schema.
+
+### [Machine learning](machine_learning.ipynb)
+
+Provides an interactive counterpart to the `genome_entropy ml` commands. It:
+
+1. Reads a single `.json` or `.json.gz` pipeline output containing multiple
+   top-level sequence records.
+2. Uses the package's production JSON loader and feature extractor, so the
+   notebook sees the same twelve ORF features as the command-line workflow.
+3. Removes records with no usable ORFs before splitting. Empty records are a
+   normal pipeline outcome when an input sequence has no ORFs passing the
+   configured thresholds.
+4. Splits at the top-level sequence-record boundary. Every ORF from a sequence
+   stays entirely in either training or testing, preventing sequence-level
+   leakage between partitions.
+5. Builds an XGBoost random forest with `XGBRFClassifier`. This is distinct
+   from the gradient-boosted XGBoost classifier used by the default CLI model:
+   the forest trains randomized trees in parallel using row and feature
+   subsampling.
+6. Evaluates held-out ORFs with a classification report, ROC AUC when both
+   classes are present, and a confusion-matrix plot.
+7. Creates a pandas table containing every held-out prediction, including both
+   `input_id` and `orf_id`, the actual and predicted labels, probability, and
+   correctness.
+8. Optionally displays a variable-importance table and horizontal bar plot.
+9. Optionally saves the trained forest in XGBoost's JSON model format.
+
+Edit the configuration cell before running the notebook. At minimum, set
+`JSON_PATH` to the consolidated pipeline output. The file must contain at least
+two top-level records with usable ORFs so one or more records can be held out
+for testing.
+
+The main tuning controls are:
+
+- `TEST_SPLIT`: fraction of usable sequence records reserved for testing.
+- `RANDOM_SEED`: makes the record split and forest reproducible.
+- `N_ESTIMATORS`: number of trees in the forest.
+- `MAX_DEPTH`: maximum complexity of each tree.
+- `SUBSAMPLE`: fraction of training ORFs sampled for each tree.
+- `COLSAMPLE_BYNODE`: fraction of variables considered at each tree node.
+- `DEVICE`: `cpu`, or `cuda` when using a GPU-enabled XGBoost installation.
+- `PLOT_FEATURE_IMPORTANCE`: enables or suppresses the importance plot.
+- `MODEL_OUTPUT`: optional destination for the trained model.
+
+Feature importance describes how strongly the fitted forest used each
+variable; it does not establish biological causation. Correlated entropy,
+length, and location features may divide importance between themselves, so the
+plot should be interpreted together with held-out performance and domain
+knowledge.

--- a/notebooks/machine_learning.ipynb
+++ b/notebooks/machine_learning.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "## 2. Imports\n",
     "\n",
-    "This notebook reuses the package's JSON parsing and feature extraction code so its input handling stays consistent with `genome_entropy ml`. Install the optional ML dependencies with `pip install -e '.[ml]'` from the repository root if needed."
+    "This notebook reuses the package's JSON parsing and feature extraction code so its input handling stays consistent with `genome_entropy ml`. From the repository root, install its complete runtime environment with `pip install -e '.[ml]' jupyterlab pandas matplotlib` if needed."
    ]
   },
   {
@@ -148,7 +148,13 @@
     "print(f\"Testing records: {len(test_records):,}\")\n",
     "print(f\"Training ORFs: {len(X_train):,}\")\n",
     "print(f\"Testing ORFs: {len(X_test):,}\")\n",
-    "print(f\"Features per ORF: {len(feature_names):,}\")"
+    "print(f\"Features per ORF: {len(feature_names):,}\")\n",
+    "\n",
+    "if np.unique(y_train).size < 2:\n",
+    "    raise ValueError(\n",
+    "        \"The training records contain only one in_genbank class. Adjust \"\n",
+    "        \"TEST_SPLIT or RANDOM_SEED, or provide records containing both classes.\"\n",
+    "    )"
    ]
   },
   {
@@ -237,6 +243,7 @@
     "print(classification_report(\n",
     "    y_test,\n",
     "    test_predictions,\n",
+    "    labels=[0, 1],\n",
     "    target_names=[\"not in GenBank\", \"in GenBank\"],\n",
     "    zero_division=0,\n",
     "))\n",

--- a/notebooks/machine_learning.ipynb
+++ b/notebooks/machine_learning.ipynb
@@ -1,0 +1,366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interactive GenBank ORF classification with XGBoost Random Forest\n",
+    "\n",
+    "This notebook reproduces the core `genome_entropy ml` workflow interactively. It reads one pipeline JSON file containing multiple top-level sequence records, removes records with no usable ORFs, keeps every sequence's ORFs together during the train/test split, trains an XGBoost random forest, and evaluates predictions on held-out records.\n",
+    "\n",
+    "The record-level split is important: an ORF from a sequence used for testing must not leak into training. The input therefore needs at least two top-level records containing usable ORFs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "\n",
+    "Set `JSON_PATH` to a `.json` or `.json.gz` file produced by `genome_entropy run`. Adjust the model and split settings as needed. XGBoost's `XGBRFClassifier` trains a random forest rather than the gradient-boosted model used by the default CLI classifier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "JSON_PATH = Path(\"/path/to/genome_entropy_results.json\")\n",
+    "TEST_SPLIT = 0.20\n",
+    "RANDOM_SEED = 42\n",
+    "\n",
+    "# XGBoost random-forest settings\n",
+    "N_ESTIMATORS = 500\n",
+    "MAX_DEPTH = 8\n",
+    "SUBSAMPLE = 0.80\n",
+    "COLSAMPLE_BYNODE = 0.80\n",
+    "N_JOBS = -1\n",
+    "DEVICE = \"cpu\"  # Change to \"cuda\" when GPU-enabled XGBoost is available.\n",
+    "\n",
+    "# Optional outputs\n",
+    "PLOT_FEATURE_IMPORTANCE = True\n",
+    "MODEL_OUTPUT = None  # For example: Path(\"xgboost_random_forest.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Imports\n",
+    "\n",
+    "This notebook reuses the package's JSON parsing and feature extraction code so its input handling stays consistent with `genome_entropy ml`. Install the optional ML dependencies with `pip install -e '.[ml]'` from the repository root if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from IPython.display import display\n",
+    "from sklearn.metrics import (\n",
+    "    ConfusionMatrixDisplay,\n",
+    "    classification_report,\n",
+    "    roc_auc_score,\n",
+    ")\n",
+    "from xgboost import XGBRFClassifier\n",
+    "\n",
+    "from genome_entropy.ml import (\n",
+    "    extract_features,\n",
+    "    filter_json_records_with_features,\n",
+    "    load_json_file,\n",
+    "    split_json_records,\n",
+    ")\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Read and validate the multi-record JSON file\n",
+    "\n",
+    "`load_json_file` accepts both plain and gzip-compressed JSON. Each top-level record represents one input sequence. Empty pipeline results and records whose ORFs cannot provide the required ML features are removed before splitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not JSON_PATH.is_file():\n",
+    "    raise FileNotFoundError(f\"Set JSON_PATH to an existing file: {JSON_PATH}\")\n",
+    "\n",
+    "all_records = load_json_file(JSON_PATH)\n",
+    "usable_records = filter_json_records_with_features(all_records)\n",
+    "\n",
+    "print(f\"Top-level records read: {len(all_records):,}\")\n",
+    "print(f\"Records with usable ORFs: {len(usable_records):,}\")\n",
+    "print(f\"Featureless records removed: {len(all_records) - len(usable_records):,}\")\n",
+    "\n",
+    "if len(usable_records) < 2:\n",
+    "    raise ValueError(\n",
+    "        \"At least two top-level records containing usable ORFs are required \"\n",
+    "        \"for record-level training and testing.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Split records and extract ORF features\n",
+    "\n",
+    "The random split is reproducible. Splitting occurs before feature extraction, at the top-level record boundary, so all ORFs from one sequence remain entirely in training or entirely in testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_records, test_records = split_json_records(\n",
+    "    usable_records,\n",
+    "    test_split=TEST_SPLIT,\n",
+    "    random_seed=RANDOM_SEED,\n",
+    ")\n",
+    "\n",
+    "X_train, y_train, feature_names, train_metadata = extract_features(\n",
+    "    train_records, return_metadata=True\n",
+    ")\n",
+    "X_test, y_test, test_feature_names, test_metadata = extract_features(\n",
+    "    test_records, return_metadata=True\n",
+    ")\n",
+    "\n",
+    "if feature_names != test_feature_names:\n",
+    "    raise ValueError(\"Training and test feature columns do not match\")\n",
+    "\n",
+    "print(f\"Training records: {len(train_records):,}\")\n",
+    "print(f\"Testing records: {len(test_records):,}\")\n",
+    "print(f\"Training ORFs: {len(X_train):,}\")\n",
+    "print(f\"Testing ORFs: {len(X_test):,}\")\n",
+    "print(f\"Features per ORF: {len(feature_names):,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Explore the feature matrices and class balance\n",
+    "\n",
+    "The target is `in_genbank`: `1` means the ORF matched a GenBank CDS annotation and `0` means it did not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_frame = pd.DataFrame(X_train, columns=feature_names)\n",
+    "train_frame[\"in_genbank\"] = y_train\n",
+    "test_frame = pd.DataFrame(X_test, columns=feature_names)\n",
+    "test_frame[\"in_genbank\"] = y_test\n",
+    "\n",
+    "display(train_frame.head())\n",
+    "display(train_frame.describe().T)\n",
+    "\n",
+    "class_balance = pd.DataFrame(\n",
+    "    {\n",
+    "        \"training\": pd.Series(y_train).value_counts().sort_index(),\n",
+    "        \"testing\": pd.Series(y_test).value_counts().sort_index(),\n",
+    "    }\n",
+    ").fillna(0).astype(int)\n",
+    "class_balance.index = class_balance.index.map({0: \"not_in_genbank\", 1: \"in_genbank\"})\n",
+    "display(class_balance)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Build and train the XGBoost random forest\n",
+    "\n",
+    "`XGBRFClassifier` creates many randomized trees in parallel. `subsample` controls row sampling and `colsample_bynode` controls feature sampling at each node. Increase `n_estimators` for a larger forest; tune depth and sampling to control complexity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = XGBRFClassifier(\n",
+    "    n_estimators=N_ESTIMATORS,\n",
+    "    max_depth=MAX_DEPTH,\n",
+    "    subsample=SUBSAMPLE,\n",
+    "    colsample_bynode=COLSAMPLE_BYNODE,\n",
+    "    objective=\"binary:logistic\",\n",
+    "    eval_metric=\"logloss\",\n",
+    "    tree_method=\"hist\",\n",
+    "    device=DEVICE,\n",
+    "    random_state=RANDOM_SEED,\n",
+    "    n_jobs=N_JOBS,\n",
+    ")\n",
+    "\n",
+    "model.fit(X_train, y_train)\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Test the model on held-out records\n",
+    "\n",
+    "Accuracy summarizes all predictions, while precision, recall, and F1 are useful when GenBank annotation classes are imbalanced. ROC AUC is calculated only when the held-out set contains both classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_predictions = model.predict(X_test).astype(int)\n",
+    "test_probabilities = model.predict_proba(X_test)[:, 1]\n",
+    "\n",
+    "print(classification_report(\n",
+    "    y_test,\n",
+    "    test_predictions,\n",
+    "    target_names=[\"not in GenBank\", \"in GenBank\"],\n",
+    "    zero_division=0,\n",
+    "))\n",
+    "\n",
+    "if np.unique(y_test).size == 2:\n",
+    "    print(f\"ROC AUC: {roc_auc_score(y_test, test_probabilities):.4f}\")\n",
+    "else:\n",
+    "    print(\"ROC AUC is undefined because the held-out records contain one class.\")\n",
+    "\n",
+    "ConfusionMatrixDisplay.from_predictions(\n",
+    "    y_test,\n",
+    "    test_predictions,\n",
+    "    display_labels=[\"not in GenBank\", \"in GenBank\"],\n",
+    "    cmap=\"Blues\",\n",
+    ")\n",
+    "plt.title(\"Held-out ORF predictions\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Inspect every held-out ORF prediction\n",
+    "\n",
+    "Including both `input_id` and `orf_id` keeps predictions identifiable when ORF names repeat between sequence records. Sort or filter this table interactively to investigate errors and uncertain predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prediction_frame = pd.DataFrame(test_metadata)\n",
+    "prediction_frame[\"actual_label\"] = y_test\n",
+    "prediction_frame[\"predicted_label\"] = test_predictions\n",
+    "prediction_frame[\"probability_in_genbank\"] = test_probabilities\n",
+    "prediction_frame[\"correct\"] = y_test == test_predictions\n",
+    "\n",
+    "display(prediction_frame.head(20))\n",
+    "display(prediction_frame.loc[~prediction_frame[\"correct\"]].head(20))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Optional variable-importance plot\n",
+    "\n",
+    "XGBoost's `feature_importances_` values summarize each variable's contribution across the forest. They show association with model decisions, not causation. Correlated variables can share or redistribute importance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "importance_frame = (\n",
+    "    pd.DataFrame(\n",
+    "        {\n",
+    "            \"feature\": feature_names,\n",
+    "            \"importance\": model.feature_importances_,\n",
+    "        }\n",
+    "    )\n",
+    "    .sort_values(\"importance\", ascending=True)\n",
+    "    .reset_index(drop=True)\n",
+    ")\n",
+    "\n",
+    "display(importance_frame.sort_values(\"importance\", ascending=False))\n",
+    "\n",
+    "if PLOT_FEATURE_IMPORTANCE:\n",
+    "    ax = importance_frame.plot.barh(\n",
+    "        x=\"feature\",\n",
+    "        y=\"importance\",\n",
+    "        figsize=(9, 6),\n",
+    "        legend=False,\n",
+    "        color=\"steelblue\",\n",
+    "    )\n",
+    "    ax.set_title(\"XGBoost random-forest variable importance\")\n",
+    "    ax.set_xlabel(\"Importance\")\n",
+    "    ax.set_ylabel(\"\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Optionally save the trained model\n",
+    "\n",
+    "XGBoost's JSON model format is portable across supported XGBoost versions and retains the tree ensemble. The feature order remains the `feature_names` list shown above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if MODEL_OUTPUT is not None:\n",
+    "    MODEL_OUTPUT = Path(MODEL_OUTPUT)\n",
+    "    MODEL_OUTPUT.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    model.save_model(MODEL_OUTPUT)\n",
+    "    print(f\"Saved model to {MODEL_OUTPUT.resolve()}\")\n",
+    "else:\n",
+    "    print(\"MODEL_OUTPUT is None; the model was not written to disk.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- add `notebooks/machine_learning.ipynb` as an interactive counterpart to the `genome_entropy ml` workflow
- load consolidated `.json` or `.json.gz` pipeline output using the package's production parsing and feature-extraction helpers
- filter featureless records and split at the top-level sequence boundary to prevent ORF leakage between training and testing
- train and evaluate an XGBoost random forest with `XGBRFClassifier`
- provide held-out classification metrics, a confusion matrix, per-ORF prediction inspection, an optional variable-importance plot, and optional model saving
- expand `notebooks/README.md` with setup, workflow, tuning, and interpretation guidance

## Why

The command-line ML workflow is useful for batch execution, while a notebook makes it easier to inspect feature distributions, tune the random forest, explore incorrect or uncertain ORF predictions, and visualize variable importance interactively on HPC systems.

## Validation

- notebook JSON parsed successfully with `python -m json.tool`
- all Python code cells compiled successfully
- notebook contains 21 independently runnable markdown/code cells
- `git diff --check` passed

The notebook was not executed end-to-end because it requires a user-selected pipeline JSON dataset and the optional Jupyter/XGBoost analysis environment.