### PR TITLE
Fix GenBank CDS matching for truncated protein translations

### DIFF
--- a/src/genome_entropy/io/genbank.py
+++ b/src/genome_entropy/io/genbank.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Union
 from Bio import SeqIO
 
 from ..logging_config import get_logger
+from ..orf.types import OrfRecord
 
 logger = get_logger(__name__)
 
@@ -157,57 +158,54 @@ def extract_cds_features(genbank_path: Union[str, Path]) -> List[GenBankCDS]:
     return cds_features
 
 
-def match_orf_to_genbank_cds(
-    orf_aa_sequence: str,
-    genbank_cds_list: List[GenBankCDS],
-    min_c_terminal_match: int = 10,
-) -> bool:
-    """Check if an ORF matches any GenBank CDS by C-terminal sequence.
+def orf_matches_genbank_cds(orf: OrfRecord, cds: GenBankCDS) -> bool:
+    """Match proteins by their strand-aware stop and exact C-terminal sequence.
 
-    Matches are determined by comparing the C-terminal (end) sequences of the
-    protein sequences. This accounts for cases where the predicted ORF may
-    not exactly match the annotated CDS start position.
-
-    Args:
-        orf_aa_sequence: Amino acid sequence of the ORF
-        genbank_cds_list: List of CDS features from GenBank
-        min_c_terminal_match: Minimum length of C-terminal sequence to match (default: 10)
-
-    Returns:
-        True if the ORF C-terminal matches any GenBank CDS, False otherwise
+    C-terminal matching recognises partial CDS translations and alternative
+    initiation residues without treating internal or N-terminal similarity as
+    evidence that two proteins are the same.
     """
-    if not orf_aa_sequence or not genbank_cds_list:
+    if orf.parent_id != cds.parent_id or orf.strand != cds.strand:
         return False
 
-    # Remove stop codon (*) from ORF sequence for comparison
-    orf_seq_clean = orf_aa_sequence.rstrip("*")
+    # get_orfs reports one-based inclusive coordinates. Biopython reports
+    # zero-based, half-open locations, so only the reverse-strand low coordinate
+    # needs an offset when comparing biological translation termination sites.
+    orf_stop = orf.end if orf.strand == "+" else orf.start
+    cds_stop = cds.end if cds.strand == "+" else cds.start + 1
+    if orf_stop != cds_stop:
+        return False
 
-    # Get C-terminal sequence (last N amino acids)
-    orf_c_terminal = orf_seq_clean[-min_c_terminal_match:]
+    def normalise(sequence: str) -> str:
+        normalised = "".join(sequence.split()).upper()
+        return normalised.removesuffix("*")
 
-    # If ORF is shorter than min match length, use the whole sequence
-    if len(orf_seq_clean) < min_c_terminal_match:
-        orf_c_terminal = orf_seq_clean
+    orf_c_terminal = normalise(orf.aa_sequence)[1:]
+    cds_c_terminal = normalise(cds.protein_sequence)[1:]
+    if not orf_c_terminal or not cds_c_terminal:
+        return False
 
-    # Check against all GenBank CDS features
+    shorter, longer = sorted(
+        (orf_c_terminal, cds_c_terminal),
+        key=len,
+    )
+    return longer.endswith(shorter)
+
+
+def match_orf_to_genbank_cds(
+    orf: OrfRecord,
+    genbank_cds_list: List[GenBankCDS],
+) -> bool:
+    """Return whether an ORF represents any annotated GenBank CDS."""
     for cds in genbank_cds_list:
-        if not cds.protein_sequence:
-            continue
-
-        cds_seq_clean = cds.protein_sequence.rstrip("*")
-
-        # Get C-terminal of CDS
-        cds_c_terminal = cds_seq_clean[-min_c_terminal_match:]
-
-        # If CDS is shorter than min match length, use the whole sequence
-        if len(cds_seq_clean) < min_c_terminal_match:
-            cds_c_terminal = cds_seq_clean
-
-        # Check if C-terminals match
-        if orf_c_terminal == cds_c_terminal:
+        if orf_matches_genbank_cds(orf, cds):
             logger.debug(
-                "ORF C-terminal matches GenBank CDS (match_length=%d)",
-                len(orf_c_terminal),
+                "ORF %s matches GenBank CDS at %s:%d-%d (%s)",
+                orf.orf_id,
+                cds.parent_id,
+                cds.start,
+                cds.end,
+                cds.strand,
             )
             return True
 

--- a/src/genome_entropy/pipeline/runner.py
+++ b/src/genome_entropy/pipeline/runner.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 from ..config import (
     DEFAULT_GENETIC_CODE_TABLE,
@@ -234,9 +234,7 @@ def run_pipeline(
             if genbank_file and genbank_cds_list:
                 logger.info("Matching ORFs to GenBank CDS annotations...")
                 for orf in orfs:
-                    orf.in_genbank = match_orf_to_genbank_cds(
-                        orf.aa_sequence, genbank_cds_list
-                    )
+                    orf.in_genbank = match_orf_to_genbank_cds(orf, genbank_cds_list)
                 matched_count = sum(1 for orf in orfs if orf.in_genbank)
                 logger.info(
                     "Matched %d/%d ORFs to GenBank CDS", matched_count, len(orfs)

--- a/tests/test_genbank.py
+++ b/tests/test_genbank.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from typing import Literal
 
 import pytest
 
@@ -9,8 +10,10 @@ from genome_entropy.io.genbank import (
     GenBankCDS,
     extract_cds_features,
     match_orf_to_genbank_cds,
+    orf_matches_genbank_cds,
     read_genbank,
 )
+from genome_entropy.orf.types import OrfRecord
 
 
 def create_test_genbank_file() -> str:
@@ -102,137 +105,185 @@ def test_extract_cds_features() -> None:
         Path(genbank_file).unlink(missing_ok=True)
 
 
-def test_match_orf_to_genbank_cds_exact_match() -> None:
-    """Test matching ORF to GenBank CDS with exact C-terminal match."""
-    # Create test CDS features
+def make_orf(
+    sequence: str,
+    *,
+    parent_id: str = "seq1",
+    start: int = 10,
+    end: int = 100,
+    strand: Literal["+", "-"] = "+",
+) -> OrfRecord:
+    """Create an ORF with get_orfs-style one-based inclusive coordinates."""
+    return OrfRecord(
+        parent_id=parent_id,
+        orf_id="orf1",
+        start=start,
+        end=end,
+        strand=strand,
+        frame=1,
+        nt_sequence="ATG",
+        aa_sequence=sequence,
+        table_id=11,
+        has_start_codon=True,
+        has_stop_codon=True,
+    )
+
+
+def make_cds(
+    sequence: str,
+    *,
+    parent_id: str = "seq1",
+    start: int = 9,
+    end: int = 100,
+    strand: str = "+",
+) -> GenBankCDS:
+    """Create a CDS with Biopython-style zero-based half-open coordinates."""
+    return GenBankCDS(parent_id, start, end, strand, sequence)
+
+
+@pytest.mark.parametrize(
+    ("orf_sequence", "cds_sequence"),
+    [
+        ("MABCDEFGHIJK", "MABCDEFGHIJK"),
+        ("MABCDEFGHIJK", "XABCDEFGHIJK"),
+        ("MABCDEFGHIJK", "XDEFGHIJK"),
+        ("XDEFGHIJK", "MABCDEFGHIJK"),
+        ("MABCDEFGHIJK*", "MABCDEFGHIJK"),
+        ("MABCDEFGHIJK", "MABCDEFGHIJK*"),
+        (" MABCD EFGHIJK* ", "mabcdefghijk*"),
+    ],
+)
+def test_orf_matches_genbank_cds_valid_c_terminal_matches(
+    orf_sequence: str,
+    cds_sequence: str,
+) -> None:
+    """Match identical, alternative-start, suffix, stop, case, and space forms."""
+    assert orf_matches_genbank_cds(
+        make_orf(orf_sequence),
+        make_cds(cds_sequence),
+    )
+
+
+@pytest.mark.parametrize(
+    ("orf_sequence", "cds_sequence"),
+    [
+        ("MABCDEFGHIJK", "MABCDEFGHIJX"),
+        ("MABCDEFGHIJK", "MABCXEFGHIJK"),
+        ("MABCDEFGHIJK", "XEFGHIJ"),
+        ("MABCDEFGHIJK", "MABCDE"),
+    ],
+)
+def test_orf_matches_genbank_cds_rejects_non_terminal_matches(
+    orf_sequence: str,
+    cds_sequence: str,
+) -> None:
+    """Reject final mismatches, region mismatches, substrings, and prefixes."""
+    assert not orf_matches_genbank_cds(
+        make_orf(orf_sequence),
+        make_cds(cds_sequence),
+    )
+
+
+def test_orf_matches_genbank_cds_requires_same_stop_coordinate() -> None:
+    """Matching sequences at different biological stops are distinct proteins."""
+    assert not orf_matches_genbank_cds(
+        make_orf("MABCDEFGHIJK", end=100),
+        make_cds("MABCDEFGHIJK", end=101),
+    )
+
+
+def test_orf_matches_genbank_cds_requires_same_strand() -> None:
+    """Matching sequences on different strands are distinct proteins."""
+    assert not orf_matches_genbank_cds(
+        make_orf("MABCDEFGHIJK", strand="+"),
+        make_cds("MABCDEFGHIJK", strand="-"),
+    )
+
+
+def test_orf_matches_genbank_cds_requires_same_parent_sequence() -> None:
+    """Coordinates on different parent sequences do not identify one protein."""
+    assert not orf_matches_genbank_cds(
+        make_orf("MABCDEFGHIJK", parent_id="seq1"),
+        make_cds("MABCDEFGHIJK", parent_id="seq2"),
+    )
+
+
+def test_orf_matches_genbank_cds_uses_reverse_strand_low_coordinate() -> None:
+    """A reverse-strand stop maps from one-based ORF to zero-based CDS start."""
+    orf = make_orf("MABCDEFGHIJK", start=150, end=250, strand="-")
+
+    assert orf_matches_genbank_cds(
+        orf,
+        make_cds("MABCDEFGHIJK", start=149, end=250, strand="-"),
+    )
+    assert not orf_matches_genbank_cds(
+        orf,
+        make_cds("MABCDEFGHIJK", start=150, end=250, strand="-"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("orf_sequence", "cds_sequence"),
+    [
+        ("", "MABC"),
+        ("MABC", ""),
+        ("M", "MABC"),
+        ("MABC", "M"),
+        ("*", "MABC"),
+        ("MABC", "*"),
+    ],
+)
+def test_orf_matches_genbank_cds_rejects_empty_comparison_sequences(
+    orf_sequence: str,
+    cds_sequence: str,
+) -> None:
+    """Empty and one-residue proteins cannot establish a C-terminal match."""
+    assert not orf_matches_genbank_cds(
+        make_orf(orf_sequence),
+        make_cds(cds_sequence),
+    )
+
+
+def test_match_orf_to_genbank_cds_matches_any_eligible_cds() -> None:
+    """Preserve successful matching when the eligible CDS is later in the list."""
+    orf = make_orf("MKSLLTSLAVVSGFLATCVAETKQEQ")
     cds_list = [
-        GenBankCDS(
-            parent_id="seq1",
-            start=0,
+        make_cds("MAAAAAAAAAAAAAAAAAAAAAAAAA", end=100),
+        make_cds("XKSLLTSLAVVSGFLATCVAETKQEQ", end=100),
+    ]
+
+    assert match_orf_to_genbank_cds(orf, cds_list)
+    assert not match_orf_to_genbank_cds(orf, [])
+
+
+def test_extracted_forward_and_reverse_cds_match_detected_orfs() -> None:
+    """Regression-test parsed CDS coordinates with partial and altered starts."""
+    genbank_file = create_test_genbank_file()
+
+    try:
+        forward_cds, reverse_cds = extract_cds_features(genbank_file)
+        forward_cds.protein_sequence = "XETKQEQ"
+        reverse_cds.protein_sequence = "XQEDPKHLLKLRQF"
+
+        forward_orf = make_orf(
+            "MKSLLTSLAVVSGFLATCVAETKQEQ",
+            parent_id="TEST_SEQ.1",
+            start=10,
             end=100,
             strand="+",
-            protein_sequence="MKSLLTSLAVVSGFLATCVAETKQEQ",
-        ),
-    ]
+        )
+        reverse_orf = make_orf(
+            "MQLLVLSCGQEDPKHLLKLRQF",
+            parent_id="TEST_SEQ.1",
+            start=150,
+            end=250,
+            strand="-",
+        )
 
-    # ORF with same C-terminal sequence
-    orf_aa = "MKSLLTSLAVVSGFLATCVAETKQEQ"
-
-    result = match_orf_to_genbank_cds(orf_aa, cds_list, min_c_terminal_match=10)
-    assert result is True
-
-
-def test_match_orf_to_genbank_cds_partial_match() -> None:
-    """Test matching ORF with different N-terminal but same C-terminal."""
-    cds_list = [
-        GenBankCDS(
-            parent_id="seq1",
-            start=0,
-            end=100,
-            strand="+",
-            protein_sequence="MKSLLTSLAVVSGFLATCVAETKQEQ",
-        ),
-    ]
-
-    # ORF with different start but same C-terminal (last 10 amino acids)
-    orf_aa = "XXXXXXXXVVSGFLATCVAETKQEQ"  # Different N-terminal, same C-terminal
-
-    result = match_orf_to_genbank_cds(orf_aa, cds_list, min_c_terminal_match=10)
-    assert result is True
-
-
-def test_match_orf_to_genbank_cds_no_match() -> None:
-    """Test ORF that doesn't match any GenBank CDS."""
-    cds_list = [
-        GenBankCDS(
-            parent_id="seq1",
-            start=0,
-            end=100,
-            strand="+",
-            protein_sequence="MKSLLTSLAVVSGFLATCVAETKQEQ",
-        ),
-    ]
-
-    # ORF with completely different sequence
-    orf_aa = "AAAAAAAAAAAAAAAAAAAAAAAAAA"
-
-    result = match_orf_to_genbank_cds(orf_aa, cds_list, min_c_terminal_match=10)
-    assert result is False
-
-
-def test_match_orf_to_genbank_cds_with_stop_codon() -> None:
-    """Test matching ORF with stop codon to CDS."""
-    cds_list = [
-        GenBankCDS(
-            parent_id="seq1",
-            start=0,
-            end=100,
-            strand="+",
-            protein_sequence="MKSLLTSLAVVSGFLATCVAETKQEQ",
-        ),
-    ]
-
-    # ORF with stop codon at end
-    orf_aa = "MKSLLTSLAVVSGFLATCVAETKQEQ*"
-
-    result = match_orf_to_genbank_cds(orf_aa, cds_list, min_c_terminal_match=10)
-    assert result is True
-
-
-def test_match_orf_to_genbank_cds_short_sequence() -> None:
-    """Test matching short ORF sequence."""
-    cds_list = [
-        GenBankCDS(
-            parent_id="seq1",
-            start=0,
-            end=30,
-            strand="+",
-            protein_sequence="MKSLLTSLA",
-        ),
-    ]
-
-    # ORF shorter than min_c_terminal_match
-    orf_aa = "MKSLLTSLA"
-
-    result = match_orf_to_genbank_cds(orf_aa, cds_list, min_c_terminal_match=10)
-    assert result is True
-
-
-def test_match_orf_to_genbank_cds_empty_inputs() -> None:
-    """Test matching with empty inputs."""
-    # Empty ORF sequence
-    result = match_orf_to_genbank_cds("", [], min_c_terminal_match=10)
-    assert result is False
-
-    # Empty CDS list
-    result = match_orf_to_genbank_cds("MKSLLTSLA", [], min_c_terminal_match=10)
-    assert result is False
-
-
-def test_match_orf_to_genbank_cds_multiple_cds() -> None:
-    """Test matching ORF against multiple CDS features."""
-    cds_list = [
-        GenBankCDS(
-            parent_id="seq1",
-            start=0,
-            end=100,
-            strand="+",
-            protein_sequence="AAAAAAAAAAAAAAAAAAAAAAAAAA",
-        ),
-        GenBankCDS(
-            parent_id="seq1",
-            start=200,
-            end=300,
-            strand="+",
-            protein_sequence="MKSLLTSLAVVSGFLATCVAETKQEQ",
-        ),
-    ]
-
-    # ORF matching second CDS
-    orf_aa = "MKSLLTSLAVVSGFLATCVAETKQEQ"
-
-    result = match_orf_to_genbank_cds(orf_aa, cds_list, min_c_terminal_match=10)
-    assert result is True
+        assert match_orf_to_genbank_cds(forward_orf, [forward_cds])
+        assert match_orf_to_genbank_cds(reverse_orf, [reverse_cds])
+    finally:
+        Path(genbank_file).unlink(missing_ok=True)
 
 
 def test_genbank_cds_dataclass() -> None:


### PR DESCRIPTION
## Summary

Updates GenBank annotation matching so that detected ORFs are recognised as annotated when they:

- terminate at the same strand-aware genomic position as a GenBank CDS;
- have matching C-terminal amino-acid sequences;
- differ at the first amino acid; or
- contain a longer N-terminal extension than the GenBank translation.

The match also requires the ORF and CDS to belong to the same parent sequence.

## Matching rule

After sequence normalisation, terminal-stop removal, and removal of the first amino acid, the shorter protein must be an exact suffix of the longer protein. Matching also requires the same strand and biological stop coordinate. The reverse-strand stop comparison converts the one-based inclusive ORF start to Biopython's zero-based, half-open CDS start convention.

## Tests

Added regression tests for:

- alternative first amino acids;
- C-terminal protein subsets in either direction;
- forward- and reverse-strand termination coordinates;
- terminal stop characters, case, and incidental whitespace;
- sequence mismatches;
- internal-substring and N-terminal-prefix false positives;
- differing stop coordinates, strands, and parent sequences;
- empty and one-residue proteins; and
- parsed forward/reverse GenBank CDS integration cases.

## Validation

- `PYTHONPATH=src pytest -q tests/test_genbank.py`: **27 passed**
- `ruff check src/genome_entropy/io/genbank.py src/genome_entropy/pipeline/runner.py tests/test_genbank.py`: **passed**
- `PYTHONPATH=/tmp/genome-entropy-lint-tools:src mypy --follow-imports=skip src/genome_entropy/io/genbank.py src/genome_entropy/pipeline/runner.py`: **passed**
- Black reported all 3 changed files would be left unchanged; the Black process timed out during shutdown in the HPC environment.
- Complete suite: `PYTHONPATH=/tmp/genome-entropy-test-deps:src /tmp/genome-entropy-test-deps/bin/pytest -q`: **171 passed, 13 failed, 13 skipped**
- Untouched `origin/main` with the identical environment: **155 passed, 13 failed, 13 skipped**. The same 13 pre-existing failures occur on both branches: 11 require unavailable PyTorch/Transformers and 2 are existing multi-GPU ordering assertion failures.