### PR TITLE
Add new ModernProst models and 12-state entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ The documentation includes:
 
 - 🧬 **ORF Finding**: Extract Open Reading Frames from DNA sequences using customizable genetic codes
 - 🔄 **Translation**: Convert ORFs to protein sequences with support for all NCBI genetic code tables
-- 🏗️ **3Di Encoding**: Predict structural alphabet tokens directly from sequences using ProstT5 or ModernProst models
-  - ModernProst-base (gbouras13/modernprost-base) - Default, newer base model
-  - ModernProst-profiles (gbouras13/modernprost-profiles) - Newer model with profile support
+- 🏗️ **Structural-state encoding**: Predict 3Di and, with multitask ModernProst models, 12-state tokens directly from protein sequences
+  - ModernProst 50M (`gbouras13/modernprost-50M`) - Default lightweight multitask model
+  - ModernProst 1B (`gbouras13/modernprost`) - Larger multitask model
+  - Deprecated ModernProst models - Legacy 3Di-only models
   - ProstT5 (Rostlab/ProstT5) - Original model, full precision
   - ProstT5 fp16 (Rostlab/ProstT5_fp16) - Original model, half precision
-- 📊 **Entropy Analysis**: Calculate Shannon entropy at DNA, ORF, protein, and 3Di levels
+- 📊 **Entropy Analysis**: Calculate Shannon entropy for DNA, ORFs, proteins, 3Di, and 12-state encodings
 - 🤖 **ML Classifier**: Train machine learning models to predict GenBank annotations from ORF features
 - ⚡ **GPU Acceleration**: Auto-detect and use CUDA, MPS (Apple Silicon), or CPU
 - 🚀 **Multi-GPU Support**: Parallelize 3Di encoding across multiple GPUs for faster processing
@@ -104,33 +105,41 @@ genome_entropy entropy --input 3di.json --output entropy.json
 
 ### Model Selection
 
-genome_entropy supports multiple models for 3Di encoding:
+genome_entropy supports multitask and legacy structural-state models:
 
 ```bash
-# Use default ModernProst base model (recommended)
+# Default lightweight multitask model
 genome_entropy run --input input.fasta --output results.json
 
-# Use ModernProst with profiles (for Foldseek profile searches)
+# Larger approximately 1B-parameter multitask model
 genome_entropy run --input input.fasta --output results.json \
-    --model gbouras13/modernprost-profiles
+    --model gbouras13/modernprost
 
-# Use original ProstT5 models
+# Deprecated legacy 3Di-only model
+genome_entropy run --input input.fasta --output results.json \
+    --model gbouras13/modernprost-base-deprecated
+
+# Original ProstT5 model
 genome_entropy run --input input.fasta --output results.json \
     --model Rostlab/ProstT5_fp16
 ```
 
 **Model Comparison:**
 
-| Model | Description | Use Case | Requirements |
-|-------|-------------|----------|--------------|
-| `gbouras13/modernprost-base` | Newer ModernProst base (default) | Faster inference, modern architecture | transformers >= 4.47.0 |
-| `gbouras13/modernprost-profiles` | ModernProst with profiles | For generating 3Di PSSM profiles for Foldseek | transformers >= 4.47.0 |
-| `Rostlab/ProstT5` | Original ProstT5 model (full precision) | Well-tested, compatible | transformers >= 4.30.0 |
-| `Rostlab/ProstT5_fp16` | Original ProstT5 model (half precision) | Well-tested, faster on GPU | transformers >= 4.30.0 |
+| Model | Parameters | 3Di | 12-state | Status |
+|-------|-----------:|----:|---------:|--------|
+| `gbouras13/modernprost-50M` | approximately 50M | yes | yes | default |
+| `gbouras13/modernprost` | approximately 1B | yes | yes | supported |
+| `gbouras13/modernprost-base-deprecated` | legacy | yes | no | deprecated |
+| `gbouras13/modernprost-profiles-deprecated` | legacy | yes | no | deprecated |
+| `Rostlab/ProstT5` | legacy | yes | no | supported |
+| `Rostlab/ProstT5_fp16` | legacy | yes | no | supported |
 
 **Notes:** 
 - ModernProst models are based on the implementation from [phold](https://github.com/gbouras13/phold) by George Bouras.
-- ModernProst models require transformers >= 4.47.0 for ModernBert support. Upgrade if needed: `pip install --upgrade 'transformers>=4.47.0'`
+- New ModernProst models require transformers >= 5.14.1 and load their published custom code with `trust_remote_code=True`.
+- The 12-state symbols `A` through `L` are a deterministic serialization of class IDs 0 through 11; the model does not publish a separate biological symbol nomenclature.
+- Legacy models serialize `twelve_state` and `twelve_state_entropy` as JSON `null`. Older JSON without these fields remains readable.
 - ModernProst models use HuggingFace's `accelerate` library for multi-GPU support, which handles model distribution automatically.
 - Install accelerate for multi-GPU: `pip install accelerate`
 
@@ -216,18 +225,18 @@ See [docs/ML_CLASSIFIER.md](docs/ML_CLASSIFIER.md) for detailed documentation an
 
 - Python 3.10 or higher
 - PyTorch >= 2.0.0 (GPU support optional)
-- Transformers >= 4.47.0 (HuggingFace) - **Required for ModernProst models**
+- Transformers >= 5.14.1 (HuggingFace) - **Required for new ModernProst models**
 - Accelerate >= 0.20.0 (HuggingFace) - **Required for ModernProst multi-GPU support**
 - pygenetic-code >= 0.20.0
 - typer >= 0.9.0
 
-**Note:** ModernProst models (`gbouras13/modernprost-base` and `gbouras13/modernprost-profiles`) require:
-- transformers >= 4.47.0 for ModernBert support
+**Note:** The multitask ModernProst models require:
+- transformers >= 5.14.1
 - accelerate >= 0.20.0 for multi-GPU support
 
 If you're using an older version, please upgrade:
 ```bash
-pip install --upgrade 'transformers>=4.47.0' 'accelerate>=0.20.0'
+pip install --upgrade 'transformers>=5.14.1' 'accelerate>=0.20.0'
 ```
 
 ### External Binary: get_orfs
@@ -263,7 +272,7 @@ genome_entropy run \
     --output results.json \
     --table 11 \
     --min-aa 30 \
-    --model gbouras13/modernprost-base \
+    --model gbouras13/modernprost-50M \
     --device auto
 ```
 
@@ -273,9 +282,11 @@ genome_entropy run \
 - `--output, -o`: Output JSON file (required)
 - `--table, -t`: NCBI genetic code table ID (default: 11)
 - `--min-aa`: Minimum protein length in amino acids (default: 30)
-- `--model, -m`: Model name (default: `gbouras13/modernprost-base`)
-  - `gbouras13/modernprost-base` - Newer ModernProst base model
-  - `gbouras13/modernprost-profiles` - Newer ModernProst with profile support
+- `--model, -m`: Model name (default: `gbouras13/modernprost-50M`)
+  - `gbouras13/modernprost-50M` - Lightweight 3Di + 12-state model
+  - `gbouras13/modernprost` - Approximately 1B-parameter 3Di + 12-state model
+  - `gbouras13/modernprost-base-deprecated` - Deprecated legacy 3Di-only model
+  - `gbouras13/modernprost-profiles-deprecated` - Deprecated legacy profile-capable 3Di-only model
   - `Rostlab/ProstT5` - Original ProstT5 model
   - `Rostlab/ProstT5_fp16` - Original ProstT5 model
 - `--device, -d`: Device for inference (auto/cuda/mps/cpu)
@@ -322,15 +333,15 @@ genome_entropy encode3di --input proteins.json --output 3di.json
 genome_entropy entropy --input 3di.json --output entropy.json
 ```
 
-### `genome_entropy encode3di` - Encode to 3Di
+### `genome_entropy encode3di` - Encode structural states
 
-Convert proteins to 3Di structural tokens using ProstT5 or ModernProst:
+Convert proteins to structural-state tokens. New ModernProst models produce both 3Di and 12-state encodings; legacy models produce only 3Di:
 
 ```bash
 genome_entropy encode3di \
     --input proteins.json \
     --output 3di.json \
-    --model gbouras13/modernprost-base \
+    --model gbouras13/modernprost-50M \
     --device auto \
     --encoding-size 10000
 ```
@@ -356,8 +367,10 @@ Pre-download ProstT5 or ModernProst models to cache:
 genome_entropy download
 
 # Download ModernProst models
-genome_entropy download --model gbouras13/modernprost-base
-genome_entropy download --model gbouras13/modernprost-profiles
+genome_entropy download --model gbouras13/modernprost-50M
+genome_entropy download --model gbouras13/modernprost
+genome_entropy download --model gbouras13/modernprost-base-deprecated
+genome_entropy download --model gbouras13/modernprost-profiles-deprecated
 ```
 
 ### `genome_entropy estimate-tokens` - Estimate Encoding Size
@@ -365,7 +378,7 @@ genome_entropy download --model gbouras13/modernprost-profiles
 Estimate a practical encoding size for the selected model and device:
 
 ```bash
-genome_entropy estimate-tokens --device cuda --model gbouras13/modernprost-base
+genome_entropy estimate-tokens --device cuda --model gbouras13/modernprost-50M
 ```
 
 ### `genome_entropy ml` - GenBank Annotation Classifier

--- a/docs/ML_CLASSIFIER.md
+++ b/docs/ML_CLASSIFIER.md
@@ -61,17 +61,31 @@ However, for typical use cases with ORF features, XGBoost will likely outperform
 
 ## Features Used for Prediction
 
-The classifier uses the following 12 features extracted from JSON output:
+New classifiers use the following 14 features extracted from JSON output. The
+original 12 features retain their order so older saved classifiers remain usable.
 
-### Entropy Features (3)
+### Entropy Features (4)
 - `dna_entropy`: Shannon entropy of nucleotide sequence
 - `protein_entropy`: Shannon entropy of amino acid sequence  
 - `three_di_entropy`: Shannon entropy of 3Di structural encoding
+- `twelve_state_entropy`: Shannon entropy of the 12-state encoding
 
-### Length Features (3)
+### Length Features (4)
 - `dna_length`: Length of nucleotide sequence
 - `protein_length`: Length of amino acid sequence
 - `three_di_length`: Length of 3Di encoding
+- `twelve_state_length`: Length of the 12-state encoding
+
+When a legacy model or older JSON file has no 12-state data, both new features
+are represented as `numpy.nan`, never zero. XGBoost preserves missing values;
+the neural-network backend applies a training-set median imputation. A classifier
+saved with the legacy 12-feature schema continues to receive exactly those 12
+features, without reordering.
+
+If an entire neural-network training column is unavailable, the persisted
+imputer uses an explicit `0.0` fallback and emits one warning. Missing values in
+the extracted data remain `numpy.nan`; the fallback is model preprocessing
+metadata rather than a serialized biological measurement.
 
 ### Position Features (2)
 - `start`: Start position in genome

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -351,7 +351,7 @@ Translation
 
    # Initialize encoder
    encoder = ModernProstThreeDiEncoder(
-       model_name="gbouras13/modernprost-base",
+       model_name="gbouras13/modernprost-50M",
        device="auto"  # Auto-detect CUDA/MPS/CPU
    )
 
@@ -456,7 +456,7 @@ Complete Pipeline
        output_json=Path("results.json"),
        table_id=11,
        min_aa_len=30,
-       model_name="gbouras13/modernprost-base",
+       model_name="gbouras13/modernprost-50M",
        device="auto",
        compute_entropy=True
    )
@@ -582,9 +582,11 @@ ThreeDiRecord
 
    @dataclass
    class ThreeDiRecord:
+       protein: ProteinRecord
        orf_id: str
        three_di: str           # 3Di token sequence
-       method: Literal["prostt5_aa2fold"]
+       twelve_state: str | None # 12-state tokens; None for legacy models
+       method: str
        model_name: str
        inference_device: str   # "cuda", "mps", or "cpu"
 
@@ -599,6 +601,7 @@ EntropyReport
        orf_nt_entropy: dict[str, float]     # orf_id → entropy
        protein_aa_entropy: dict[str, float]
        three_di_entropy: dict[str, float]
+       twelve_state_entropy: dict[str, float] | None
        alphabet_sizes: dict[str, int]
 
 Type Hints

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -73,11 +73,11 @@ Run the complete pipeline from DNA to 3Di with entropy analysis.
 ``--model, -m TEXT``
    3Di model name from HuggingFace
    
-   Default: gbouras13/modernprost-base
+   Default: gbouras13/modernprost-50M
 
-   Supported models include ``gbouras13/modernprost-base``,
-   ``gbouras13/modernprost-profiles``, ``Rostlab/ProstT5``, and
-   ``Rostlab/ProstT5_fp16``.
+   Supported models include the multitask ``gbouras13/modernprost-50M`` and
+   ``gbouras13/modernprost`` models, both deprecated ModernProst repositories,
+   and both ProstT5 repositories.
 
 ``--device, -d TEXT``
    Device for inference (auto, cuda, mps, cpu). Ignored when ``--multi-gpu`` is set.
@@ -211,7 +211,8 @@ Translate ORFs to protein sequences.
 encode3di
 ^^^^^^^^^
 
-Encode protein sequences to 3Di structural tokens using ModernProst or ProstT5.
+Encode proteins into structural-state sequences. New ModernProst models produce
+both 3Di and 12-state encodings; legacy models produce only 3Di.
 
 **Usage:**
 
@@ -234,11 +235,11 @@ Encode protein sequences to 3Di structural tokens using ModernProst or ProstT5.
 ``--model, -m TEXT``
    3Di model name
    
-   Default: gbouras13/modernprost-base
+   Default: gbouras13/modernprost-50M
 
-   Supported models include ``gbouras13/modernprost-base``,
-   ``gbouras13/modernprost-profiles``, ``Rostlab/ProstT5``, and
-   ``Rostlab/ProstT5_fp16``.
+   Supported models include ``gbouras13/modernprost-50M``,
+   ``gbouras13/modernprost``, the two ``-deprecated`` ModernProst repositories,
+   ``Rostlab/ProstT5``, and ``Rostlab/ProstT5_fp16``.
 
 ``--device, -d TEXT``
    Device for inference (auto, cuda, mps, cpu). Ignored when ``--multi-gpu`` is set.
@@ -370,7 +371,7 @@ Pre-download ModernProst or ProstT5 models to the HuggingFace cache.
 ``--model, -m TEXT``
    Model name to download
    
-   Default: gbouras13/modernprost-base
+   Default: gbouras13/modernprost-50M
 
 ``--test-data``
    Request test datasets. This option is currently a placeholder; use
@@ -407,7 +408,7 @@ Estimate optimal encoding size for your GPU.
 ``--model, -m TEXT``
    3Di model name
    
-   Default: gbouras13/modernprost-base
+   Default: gbouras13/modernprost-50M
 
 ``--start INTEGER``
    Starting encoding size to test

--- a/docs/unified_output_format.md
+++ b/docs/unified_output_format.md
@@ -44,16 +44,22 @@ The previous output format (v1.x) contained significant redundancy:
 
 The new format uses a single `features` dictionary where each ORF appears exactly once with all its related data organized hierarchically:
 
+Schema 2.1 adds the optional 12-state structural representation and its entropy.
+Legacy models write both values as JSON `null`; they are not represented as zero
+or an empty string. Readers also accept older files where these fields are absent
+and treat the values as unavailable.
+
 ```json
 {
-  "schema_version": "2.0.0",
+  "schema_version": "2.1.0",
   "input_id": "sequence_name",
   "input_dna_length": 1000,
   "dna_entropy_global": 1.85,
   "alphabet_sizes": {
     "dna": 4,
     "protein": 20,
-    "three_di": 20
+    "three_di": 20,
+    "twelve_state": 12
   },
   "features": {
     "orf_1": {
@@ -79,6 +85,10 @@ The new format uses a single `features` dictionary where each ORF appears exactl
         "model_name": "Rostlab/ProstT5",
         "inference_device": "cpu"
       },
+      "twelve_state": {
+        "encoding": "ABCDABCD...",
+        "length": 100
+      },
       "metadata": {
         "parent_id": "sequence_name",
         "table_id": 11,
@@ -89,7 +99,8 @@ The new format uses a single `features` dictionary where each ORF appears exactl
       "entropy": {
         "dna_entropy": 1.2,
         "protein_entropy": 0.8,
-        "three_di_entropy": 0.0
+        "three_di_entropy": 0.0,
+        "twelve_state_entropy": 1.95
       }
     }
   }
@@ -110,11 +121,11 @@ The new format uses a single `features` dictionary where each ORF appears exactl
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `schema_version` | string | Format version (e.g., "2.0.0") |
+| `schema_version` | string | Format version (e.g., "2.1.0") |
 | `input_id` | string | ID of the input DNA sequence |
 | `input_dna_length` | integer | Length of input DNA in nucleotides |
 | `dna_entropy_global` | float | Shannon entropy of entire DNA sequence |
-| `alphabet_sizes` | object | Size of each alphabet (dna: 4, protein: 20, three_di: 20) |
+| `alphabet_sizes` | object | Alphabet sizes (dna: 4, protein: 20, three_di: 20, twelve_state: 12) |
 | `features` | object | Dictionary of features keyed by `orf_id` |
 
 ### Feature Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "torch>=2.0.0",
-    "transformers>=4.47.0",  # ModernBert support required for modernprost models
+    "transformers>=5.14.1",  # Required by the new ModernProst remote code
     "accelerate>=0.20.0",  # Multi-GPU support for ModernProst models
     "pygenetic_code>=0.20.0",
     "typer>=0.9.0",

--- a/src/genome_entropy/cli/commands/download.py
+++ b/src/genome_entropy/cli/commands/download.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     typer = None
 
+from ...config import DEFAULT_PROSTT5_MODEL, supported_models_help
+
 
 def _is_model_cached(model_name: str) -> bool:
     """Check if a model is already cached locally.
@@ -38,10 +40,10 @@ def _is_model_cached(model_name: str) -> bool:
 
 def download_command(
     model: str = typer.Option(
-        "gbouras13/modernprost-base",
+        DEFAULT_PROSTT5_MODEL,
         "--model",
         "-m",
-        help="Model to download (gbouras13/modernprost-base, gbouras13/modernprost-profiles, Rostlab/ProstT5, or Rostlab/ProstT5_fp16)",
+        help=supported_models_help(),
     ),
     test_data: bool = typer.Option(
         False,
@@ -56,7 +58,16 @@ def download_command(
     """
     try:
         from transformers import AutoModel, AutoTokenizer
-        from ...config import MODERNPROST_MODELS
+        from ...config import get_model_capabilities, resolve_model_name
+
+        model = resolve_model_name(model)
+        capabilities = get_model_capabilities(model, warn=False)
+        if capabilities.deprecated:
+            typer.echo(
+                "Warning: selected model is deprecated and produces only 3Di; "
+                "12-state values will be null.",
+                err=True,
+            )
 
         typer.echo(f"Downloading model: {model}")
 
@@ -68,19 +79,18 @@ def download_command(
             typer.echo("This may take a few minutes on first run...")
 
         # Check if this is a ModernProst model
-        is_modernprost = model in MODERNPROST_MODELS
+        is_modernprost = capabilities.family.startswith("modernprost")
 
-        # Download tokenizer
-        typer.echo("  - Downloading tokenizer...")
+        typer.echo("  - Downloading tokenizer and model...")
         if is_modernprost:
-            tokenizer = AutoTokenizer.from_pretrained(
-                model,
-                trust_remote_code=True,
-                local_files_only=is_cached,
-                force_download=not is_cached,
-            )
+            # Reuse the encoder's trusted-remote-code compatibility path so the
+            # multitask repository's sibling imports and cache are handled alike.
+            from ...encode3di.modernprost import ModernProstThreeDiEncoder
+
+            encoder = ModernProstThreeDiEncoder(model, device="cpu")
+            encoder._load_model()
         else:
-            tokenizer = AutoTokenizer.from_pretrained(
+            AutoTokenizer.from_pretrained(
                 model,
                 use_fast=False,
                 legacy=True,
@@ -88,17 +98,7 @@ def download_command(
                 force_download=not is_cached,
             )
 
-        # Download model
-        typer.echo("  - Downloading model...")
-        if is_modernprost:
-            model_obj = AutoModel.from_pretrained(
-                model,
-                trust_remote_code=True,
-                local_files_only=is_cached,
-                force_download=not is_cached,
-            )
-        else:
-            model_obj = AutoModel.from_pretrained(
+            AutoModel.from_pretrained(
                 model,
                 local_files_only=is_cached,
                 force_download=not is_cached,
@@ -121,9 +121,9 @@ def download_command(
         # Check if it's a ModernBert-related error
         if "ModernBertModel" in error_msg or "ModernBert" in error_msg:
             typer.echo("\n" + "=" * 60, err=True)
-            typer.echo("ModernProst models require transformers >= 4.47.0", err=True)
+            typer.echo("ModernProst models require transformers >= 5.14.1", err=True)
             typer.echo("Please upgrade transformers:", err=True)
-            typer.echo("  pip install --upgrade 'transformers>=4.47.0'", err=True)
+            typer.echo("  pip install --upgrade 'transformers>=5.14.1'", err=True)
             typer.echo("=" * 60, err=True)
         else:
             typer.echo("Error: transformers package required", err=True)

--- a/src/genome_entropy/cli/commands/encode3di.py
+++ b/src/genome_entropy/cli/commands/encode3di.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     typer = None
 
+from ...config import DEFAULT_PROSTT5_MODEL, supported_models_help
+
 
 def encode3di_command(
     input: Path = typer.Option(
@@ -23,13 +25,13 @@ def encode3di_command(
         ...,
         "--output",
         "-o",
-        help="Output JSON file with 3Di records",
+        help="Output JSON file with structural-state records",
     ),
     model: str = typer.Option(
-        "gbouras13/modernprost-base",
+        DEFAULT_PROSTT5_MODEL,
         "--model",
         "-m",
-        help="Model name (gbouras13/modernprost-base, gbouras13/modernprost-profiles, Rostlab/ProstT5, or Rostlab/ProstT5_fp16)",
+        help=supported_models_help(),
     ),
     device: Optional[str] = typer.Option(
         None,
@@ -55,18 +57,20 @@ def encode3di_command(
         "If not specified, auto-discovers available GPUs.",
     ),
 ) -> None:
-    """Encode proteins to 3Di structural tokens.
+    """Encode proteins into structural-state sequences.
 
-    Uses ProstT5 or ModernProst models to predict 3Di structural alphabet tokens
-    directly from amino acid sequences.
+    New ModernProst models produce both 3Di and 12-state encodings; legacy
+    ModernProst and ProstT5 models produce only 3Di.
 
     Input formats:
     - FASTA file: Protein sequences in FASTA format (.fasta, .fa, .faa)
     - JSON file: Protein records in JSON format (output from translate or fasta-to-protein)
 
     Available models:
-    - gbouras13/modernprost-base (default, newer base model, fastest)
-    - gbouras13/modernprost-profiles (newer model with profile support)
+    - gbouras13/modernprost-50M (default; 3Di and 12-state)
+    - gbouras13/modernprost (larger; 3Di and 12-state)
+    - gbouras13/modernprost-base-deprecated (legacy 3Di only)
+    - gbouras13/modernprost-profiles-deprecated (legacy 3Di only)
     - Rostlab/ProstT5 (original ProstT5 model, full precision)
     - Rostlab/ProstT5_fp16 (original ProstT5 model, half precision)
 
@@ -75,7 +79,7 @@ def encode3di_command(
     specify --gpu-ids to select specific GPUs.
     """
     try:
-        from ...config import MODERNPROST_MODELS
+        from ...config import get_model_capabilities, resolve_model_name
         from ...encode3di.prostt5 import ProstT5ThreeDiEncoder
         from ...encode3di.modernprost import ModernProstThreeDiEncoder
         from ...io.jsonio import read_json, write_json
@@ -94,16 +98,16 @@ def encode3di_command(
                 raise typer.Exit(2)
 
         typer.echo(f"Reading proteins from: {input}")
-        
+
         # Detect input format based on file extension
         input_str = str(input).lower()
-        is_fasta = input_str.endswith(('.fasta', '.fa', '.faa'))
-        
+        is_fasta = input_str.endswith((".fasta", ".fa", ".faa"))
+
         if is_fasta:
             # Read FASTA file and convert to ProteinRecord objects
             typer.echo("  Detected FASTA format")
             sequences = read_fasta(input)
-            
+
             # Convert to ProteinRecord objects (similar to fasta_to_protein)
             proteins = []
             for seq_id, aa_sequence in sequences.items():
@@ -123,7 +127,7 @@ def encode3di_command(
                     has_stop_codon=False,
                     in_genbank=False,
                 )
-                
+
                 protein = ProteinRecord(
                     orf=orf,
                     aa_sequence=aa_sequence,
@@ -134,7 +138,7 @@ def encode3di_command(
             # Read JSON file (original behavior)
             typer.echo("  Detected JSON format")
             protein_data = read_json(input)
-            
+
             # Reconstruct ProteinRecord objects
             if isinstance(protein_data, list):
                 proteins = []
@@ -153,7 +157,9 @@ def encode3di_command(
 
         # Select encoder based on model name
         typer.echo(f"\nInitializing encoder (model: {model})...")
-        if model in MODERNPROST_MODELS:
+        model = resolve_model_name(model)
+        capabilities = get_model_capabilities(model, warn=False)
+        if capabilities.family.startswith("modernprost"):
             encoder = ModernProstThreeDiEncoder(model_name=model, device=device)
         else:
             encoder = ProstT5ThreeDiEncoder(model_name=model, device=device)
@@ -167,7 +173,7 @@ def encode3di_command(
         else:
             typer.echo(f"  Using device: {encoder.device}")
 
-        typer.echo(f"\nEncoding to 3Di tokens...")
+        typer.echo("\nEncoding structural-state tokens...")
         three_dis = encoder.encode_proteins(
             proteins,
             encoding_size,
@@ -179,7 +185,8 @@ def encode3di_command(
         typer.echo(f"\nWriting results to: {output}")
         write_json(three_dis, output)
 
-        typer.echo("✓ 3Di encoding complete!")
+        # Keep the established completion text for scripts that inspect stdout.
+        typer.echo("✓ 3Di encoding complete! Structural-state output written.")
 
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)

--- a/src/genome_entropy/cli/commands/entropy.py
+++ b/src/genome_entropy/cli/commands/entropy.py
@@ -32,7 +32,7 @@ def entropy_command(
 ) -> None:
     """Calculate Shannon entropy at all representation levels.
 
-    Computes entropy for DNA, ORF nucleotides, proteins, and 3Di tokens.
+    Computes entropy for DNA, ORF nucleotides, proteins, 3Di, and 12-state tokens.
     """
     try:
         from ...entropy.shannon import calculate_entropies_for_sequences, EntropyReport
@@ -40,6 +40,14 @@ def entropy_command(
         from ...orf.types import OrfRecord
         from ...translate.translator import ProteinRecord
         from ...encode3di.prostt5 import ThreeDiRecord
+        from ...config import (
+            AA_ALPHABET,
+            DNA_ALPHABET,
+            THREEDDI_ALPHABET,
+            TWELVE_STATE_ALPHABET,
+            THREEDDI_ALPHABET_SIZE,
+            TWELVE_STATE_ALPHABET_SIZE,
+        )
 
         typer.echo(f"Reading 3Di records from: {input}")
         three_di_data = read_json(input)
@@ -60,6 +68,7 @@ def entropy_command(
                     method=td["method"],
                     model_name=td["model_name"],
                     inference_device=td["inference_device"],
+                    twelve_state=td.get("twelve_state"),
                 )
                 three_dis.append(three_di)
         else:
@@ -77,15 +86,29 @@ def entropy_command(
             td.protein.orf.orf_id: td.protein.aa_sequence for td in three_dis
         }
         three_di_seqs = {td.protein.orf.orf_id: td.three_di for td in three_dis}
+        twelve_state_seqs = {
+            td.protein.orf.orf_id: td.twelve_state
+            for td in three_dis
+            if td.twelve_state is not None
+        }
 
         orf_nt_entropy = calculate_entropies_for_sequences(
-            orf_nt_seqs, normalize=normalize
+            orf_nt_seqs, alphabet=DNA_ALPHABET, normalize=normalize
         )
         protein_aa_entropy = calculate_entropies_for_sequences(
-            protein_aa_seqs, normalize=normalize
+            protein_aa_seqs, alphabet=AA_ALPHABET, normalize=normalize
         )
         three_di_entropy = calculate_entropies_for_sequences(
-            three_di_seqs, normalize=normalize
+            three_di_seqs, alphabet=THREEDDI_ALPHABET, normalize=normalize
+        )
+        twelve_state_entropy = (
+            calculate_entropies_for_sequences(
+                twelve_state_seqs,
+                alphabet=TWELVE_STATE_ALPHABET,
+                normalize=normalize,
+            )
+            if twelve_state_seqs
+            else None
         )
 
         # Create report
@@ -94,7 +117,13 @@ def entropy_command(
             orf_nt_entropy=orf_nt_entropy,
             protein_aa_entropy=protein_aa_entropy,
             three_di_entropy=three_di_entropy,
-            alphabet_sizes={"dna": 4, "protein": 20, "three_di": 20},
+            alphabet_sizes={
+                "dna": 4,
+                "protein": 20,
+                "three_di": THREEDDI_ALPHABET_SIZE,
+                "twelve_state": TWELVE_STATE_ALPHABET_SIZE,
+            },
+            twelve_state_entropy=twelve_state_entropy,
         )
 
         typer.echo(f"  Calculated entropy for {len(orf_nt_entropy)} sequence(s)")

--- a/src/genome_entropy/cli/commands/estimate_tokens.py
+++ b/src/genome_entropy/cli/commands/estimate_tokens.py
@@ -9,13 +9,15 @@ try:
 except ImportError:
     typer = None
 
+from ...config import DEFAULT_PROSTT5_MODEL, supported_models_help
+
 
 def estimate_token_size_command(
     model: str = typer.Option(
-        "gbouras13/modernprost-base",
+        DEFAULT_PROSTT5_MODEL,
         "--model",
         "-m",
-        help="Model name (gbouras13/modernprost-base, gbouras13/modernprost-profiles, Rostlab/ProstT5, or Rostlab/ProstT5_fp16)",
+        help=supported_models_help(),
     ),
     device: Optional[str] = typer.Option(
         None,
@@ -73,9 +75,17 @@ def estimate_token_size_command(
     The recommended token size is returned as 90% of the maximum for safety.
     """
     try:
-        from ...config import VALID_LOG_LEVELS, MODERNPROST_MODELS
+        from ...config import (
+            VALID_LOG_LEVELS,
+            get_model_capabilities,
+            resolve_model_name,
+        )
         from ...logging_config import configure_logging
-        from ...encode3di import ProstT5ThreeDiEncoder, ModernProstThreeDiEncoder, estimate_token_size
+        from ...encode3di import (
+            ProstT5ThreeDiEncoder,
+            ModernProstThreeDiEncoder,
+            estimate_token_size,
+        )
 
         # Validate and configure logging
         if log_level.upper() not in VALID_LOG_LEVELS:
@@ -98,7 +108,9 @@ def estimate_token_size_command(
 
         # Select encoder based on model name
         typer.echo("\nInitializing encoder...")
-        if model in MODERNPROST_MODELS:
+        model = resolve_model_name(model)
+        capabilities = get_model_capabilities(model, warn=False)
+        if capabilities.family.startswith("modernprost"):
             encoder = ModernProstThreeDiEncoder(model_name=model, device=device)
         else:
             encoder = ProstT5ThreeDiEncoder(model_name=model, device=device)

--- a/src/genome_entropy/cli/commands/run.py
+++ b/src/genome_entropy/cli/commands/run.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     typer = None
 
+from ...config import DEFAULT_PROSTT5_MODEL, supported_models_help
+
 
 def run_command(
     input: Optional[Path] = typer.Option(
@@ -36,10 +38,10 @@ def run_command(
         help="Minimum protein length in amino acids",
     ),
     model: str = typer.Option(
-        "gbouras13/modernprost-base",
+        DEFAULT_PROSTT5_MODEL,
         "--model",
         "-m",
-        help="Model name (gbouras13/modernprost-base, gbouras13/modernprost-profiles, Rostlab/ProstT5, or Rostlab/ProstT5_fp16)",
+        help=supported_models_help(),
     ),
     device: Optional[str] = typer.Option(
         None,
@@ -91,12 +93,12 @@ def run_command(
         help="Path to log file (default: log to STDOUT)",
     ),
 ) -> None:
-    """Run the complete DNA to 3Di pipeline.
+    """Run the complete structural-state entropy pipeline.
 
     Executes all pipeline steps:
     1. Find ORFs in DNA sequences
     2. Translate ORFs to proteins
-    3. Encode proteins to 3Di tokens
+    3. Encode proteins to 3Di and, for new ModernProst models, 12-state tokens
     4. Calculate entropy at all levels
     5. Optionally match ORFs to GenBank CDS annotations
 

--- a/src/genome_entropy/cli/main.py
+++ b/src/genome_entropy/cli/main.py
@@ -16,7 +16,7 @@ from ..logging_config import configure_logging
 if typer:
     app = typer.Typer(
         name="genome_entropy",
-        help="DNA to 3Di pipeline: Convert DNA sequences to ORFs, proteins, and 3Di structural tokens with entropy analysis.",
+        help="Convert DNA to proteins and structural-state encodings with entropy analysis.",
         add_completion=False,
     )
 
@@ -38,7 +38,7 @@ if typer:
             help="Path to log file (default: log to STDOUT)",
         ),
     ) -> None:
-        """DNA to 3Di pipeline with entropy analysis."""
+        """DNA-to-structural-state pipeline with entropy analysis."""
         if version:
             typer.echo(f"genome_entropy version {__version__}")
             raise typer.Exit()

--- a/src/genome_entropy/config.py
+++ b/src/genome_entropy/config.py
@@ -1,55 +1,155 @@
-"""Configuration and constants for genome_entropy."""
+"""Configuration, model capabilities, and constants for genome_entropy."""
 
 import os
-from pathlib import Path
+import warnings
+from dataclasses import dataclass
+from typing import Dict, Literal
 
-# Default NCBI translation table (Bacterial/Archaeal)
 DEFAULT_GENETIC_CODE_TABLE = 11
+DEFAULT_MIN_NT_LENGTH = 90
+DEFAULT_MIN_AA_LENGTH = 30
 
-# Minimum ORF lengths
-DEFAULT_MIN_NT_LENGTH = 90  # nucleotides
-DEFAULT_MIN_AA_LENGTH = 30  # amino acids
-
-# ProstT5 model configuration
-DEFAULT_PROSTT5_MODEL = "gbouras13/modernprost-base"
-MODERNPROST_BASE_MODEL = "gbouras13/modernprost-base"
-MODERNPROST_PROFILES_MODEL = "gbouras13/modernprost-profiles"
+MODERNPROST_50M_MODEL = "gbouras13/modernprost-50M"
+MODERNPROST_1B_MODEL = "gbouras13/modernprost"
+MODERNPROST_BASE_DEPRECATED_MODEL = "gbouras13/modernprost-base-deprecated"
+MODERNPROST_PROFILES_DEPRECATED_MODEL = "gbouras13/modernprost-profiles-deprecated"
+# Backward-compatible constant imports now point at the renamed repositories.
+MODERNPROST_BASE_MODEL = MODERNPROST_BASE_DEPRECATED_MODEL
+MODERNPROST_PROFILES_MODEL = MODERNPROST_PROFILES_DEPRECATED_MODEL
+PROSTT5_MODEL = "Rostlab/ProstT5"
+PROSTT5_FP16_MODEL = "Rostlab/ProstT5_fp16"
+DEFAULT_PROSTT5_MODEL = MODERNPROST_50M_MODEL
 DEFAULT_ENCODING_SIZE = 10000
 
-# Model types
-PROSTT5_MODELS = {"Rostlab/ProstT5_fp16", "Rostlab/ProstT5"}
-MODERNPROST_MODELS = {MODERNPROST_BASE_MODEL, MODERNPROST_PROFILES_MODEL}
 
-# 3Di alphabet (20 structural states)
-THREEDDI_ALPHABET = set("ACDEFGHIKLMNPQRSTVWY")
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """Capabilities and provenance for one supported Hugging Face model."""
 
-# DNA alphabet
+    model_name: str
+    family: Literal["modernprost_multitask", "modernprost_legacy", "prostt5"]
+    supports_3di: bool
+    supports_12st: bool
+    supports_profiles: bool = False
+    deprecated: bool = False
+    description: str = ""
+
+
+MODEL_REGISTRY: Dict[str, ModelCapabilities] = {
+    MODERNPROST_50M_MODEL: ModelCapabilities(
+        MODERNPROST_50M_MODEL,
+        "modernprost_multitask",
+        True,
+        True,
+        description="Default approximately 50M-parameter dual-head ModernProst model",
+    ),
+    MODERNPROST_1B_MODEL: ModelCapabilities(
+        MODERNPROST_1B_MODEL,
+        "modernprost_multitask",
+        True,
+        True,
+        description="Larger approximately 1B-parameter dual-head ModernProst model",
+    ),
+    MODERNPROST_BASE_DEPRECATED_MODEL: ModelCapabilities(
+        MODERNPROST_BASE_DEPRECATED_MODEL,
+        "modernprost_legacy",
+        True,
+        False,
+        deprecated=True,
+        description="Deprecated legacy ModernProst base model (3Di only)",
+    ),
+    MODERNPROST_PROFILES_DEPRECATED_MODEL: ModelCapabilities(
+        MODERNPROST_PROFILES_DEPRECATED_MODEL,
+        "modernprost_legacy",
+        True,
+        False,
+        supports_profiles=True,
+        deprecated=True,
+        description="Deprecated legacy ModernProst profiles model (3Di only)",
+    ),
+    PROSTT5_MODEL: ModelCapabilities(
+        PROSTT5_MODEL,
+        "prostt5",
+        True,
+        False,
+        description="Original ProstT5 model (3Di only)",
+    ),
+    PROSTT5_FP16_MODEL: ModelCapabilities(
+        PROSTT5_FP16_MODEL,
+        "prostt5",
+        True,
+        False,
+        description="Original half-precision ProstT5 model (3Di only)",
+    ),
+}
+
+MODEL_ALIASES = {
+    "gbouras13/modernprost-base": MODERNPROST_BASE_DEPRECATED_MODEL,
+    "gbouras13/modernprost-profiles": MODERNPROST_PROFILES_DEPRECATED_MODEL,
+}
+
+
+def resolve_model_name(model_name: str, *, warn: bool = True) -> str:
+    """Resolve old repository aliases and validate a supported model identifier."""
+    resolved = MODEL_ALIASES.get(model_name, model_name)
+    if resolved != model_name and warn:
+        warnings.warn(
+            f"Model {model_name!r} was renamed; using {resolved!r}.",
+            FutureWarning,
+            stacklevel=2,
+        )
+    if resolved not in MODEL_REGISTRY:
+        supported = ", ".join(MODEL_REGISTRY)
+        raise ValueError(
+            f"Unsupported model {model_name!r}. Supported models: {supported}"
+        )
+    return resolved
+
+
+def get_model_capabilities(model_name: str, *, warn: bool = True) -> ModelCapabilities:
+    """Return central capability metadata for a model or legacy alias."""
+    return MODEL_REGISTRY[resolve_model_name(model_name, warn=warn)]
+
+
+def supported_models_help() -> str:
+    """Return CLI help text generated from the central model registry."""
+    return "Supported models: " + ", ".join(
+        f"{name} ({caps.description})" for name, caps in MODEL_REGISTRY.items()
+    )
+
+
+PROSTT5_MODELS = {
+    name for name, caps in MODEL_REGISTRY.items() if caps.family == "prostt5"
+}
+MODERNPROST_MODELS = {
+    name
+    for name, caps in MODEL_REGISTRY.items()
+    if caps.family.startswith("modernprost")
+} | set(MODEL_ALIASES)
+
+THREEDDI_ALPHABET_ORDERED = "ACDEFGHIKLMNPQRSTVWY"
+# No symbolic nomenclature is exposed by the model; these characters serialize IDs 0-11.
+TWELVE_STATE_ALPHABET_ORDERED = "ABCDEFGHIJKL"
+THREEDDI_ALPHABET = set(THREEDDI_ALPHABET_ORDERED)
+TWELVE_STATE_ALPHABET = set(TWELVE_STATE_ALPHABET_ORDERED)
+THREEDDI_ALPHABET_SIZE = 20
+TWELVE_STATE_ALPHABET_SIZE = 12
+
 DNA_ALPHABET = set("ACGT")
 DNA_ALPHABET_WITH_N = set("ACGTN")
-
-# Amino acid alphabet (standard 20 + ambiguous X + stop *)
 AA_ALPHABET = set("ACDEFGHIKLMNPQRSTVWY")
 AA_ALPHABET_EXTENDED = set("ACDEFGHIKLMNPQRSTVWYX*")
 
-# External binary paths
 GET_ORFS_BINARY = os.environ.get("GET_ORFS_PATH", "get_orfs")
-
-# Device selection for PyTorch
 AUTO_DEVICE = "auto"
 CUDA_DEVICE = "cuda"
 MPS_DEVICE = "mps"
 CPU_DEVICE = "cpu"
-
-# File formats
 FASTA_EXTENSIONS = {".fasta", ".fa", ".fna", ".faa"}
 JSON_EXTENSIONS = {".json"}
-
-# Exit codes
 EXIT_SUCCESS = 0
 EXIT_GENERAL_ERROR = 1
 EXIT_USER_ERROR = 2
 EXIT_RUNTIME_ERROR = 3
-
-# Logging configuration
 DEFAULT_LOG_LEVEL = "INFO"
 VALID_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/src/genome_entropy/encode3di/__init__.py
+++ b/src/genome_entropy/encode3di/__init__.py
@@ -3,7 +3,7 @@
 # Export main classes and functions
 from .encoder import ProstT5ThreeDiEncoder
 from .modernprost import ModernProstThreeDiEncoder
-from .types import IndexedSeq, ThreeDiRecord
+from .types import IndexedSeq, StructuralEncoding, ThreeDiRecord
 from .token_estimator import (
     estimate_token_size,
     generate_random_protein,
@@ -14,6 +14,7 @@ __all__ = [
     "ProstT5ThreeDiEncoder",
     "ModernProstThreeDiEncoder",
     "ThreeDiRecord",
+    "StructuralEncoding",
     "IndexedSeq",
     "estimate_token_size",
     "generate_random_protein",

--- a/src/genome_entropy/encode3di/encoder.py
+++ b/src/genome_entropy/encode3di/encoder.py
@@ -15,7 +15,7 @@ from ..config import (
     CPU_DEVICE,
     CUDA_DEVICE,
     DEFAULT_ENCODING_SIZE,
-    DEFAULT_PROSTT5_MODEL,
+    PROSTT5_FP16_MODEL,
     MPS_DEVICE,
 )
 from ..errors import DeviceError, ModelError
@@ -36,7 +36,7 @@ class ProstT5ThreeDiEncoder:
 
     def __init__(
         self,
-        model_name: str = DEFAULT_PROSTT5_MODEL,
+        model_name: str = PROSTT5_FP16_MODEL,
         device: Optional[str] = None,
     ):
         """Initialize the ProstT5 encoder.
@@ -399,6 +399,7 @@ class ProstT5ThreeDiEncoder:
                 method="prostt5_aa2fold",
                 model_name=self.model_name,
                 inference_device=self.device,
+                twelve_state=None,
             )
             records.append(record)
 

--- a/src/genome_entropy/encode3di/encoding.py
+++ b/src/genome_entropy/encode3di/encoding.py
@@ -3,7 +3,7 @@
 import math
 import re
 import time
-from typing import Any, Callable, Iterator, List, Tuple
+from typing import Any, Callable, Iterator, List, Tuple, TypeVar
 
 try:
     import torch
@@ -14,6 +14,7 @@ from ..errors import EncodingError
 from ..logging_config import get_logger
 
 logger = get_logger(__name__)
+EncodingT = TypeVar("EncodingT")
 
 
 def preprocess_sequences(aa_sequences: List[str]) -> List[str]:
@@ -63,10 +64,10 @@ def get_memory_info() -> Tuple[float, float]:
 
 def process_batches(
     batches_iter: Iterator[Any],
-    encode_batch_fn: Callable[[List[str]], List[str]],
+    encode_batch_fn: Callable[[List[str]], List[EncodingT]],
     total_sequences: int,
     total_batches: int,
-) -> List[str]:
+) -> List[EncodingT]:
     """Process batches of sequences and return results in original order.
 
     Args:
@@ -82,7 +83,7 @@ def process_batches(
         EncodingError: If encoding fails
         RuntimeError: If some sequences were not encoded
     """
-    three_di_sequences: List[str] = [None] * total_sequences  # type: ignore[list-item]
+    encodings: List[EncodingT | None] = [None] * total_sequences
 
     processed_sequences = 0
     t0 = time.perf_counter()
@@ -135,7 +136,7 @@ def process_batches(
 
             # Reorder results to match original input order
             for bi, br in zip(batch_idxs, batch_results):
-                three_di_sequences[bi] = br
+                encodings[bi] = br
 
             # Update timing
             batch_elapsed = time.perf_counter() - batch_start
@@ -149,22 +150,22 @@ def process_batches(
         raise EncodingError(f"Failed to encode sequences: {e}") from e
 
     # Check all sequences encoded
-    missing = [i for i, v in enumerate(three_di_sequences) if v is None]
+    missing = [i for i, value in enumerate(encodings) if value is None]
     if missing:
         raise RuntimeError(
             f"Missing encodings for {len(missing)} sequences "
             f"(e.g., indices {missing[:10]})"
         )
 
-    return three_di_sequences
+    return [value for value in encodings if value is not None]
 
 
 def encode(
     aa_sequences: List[str],
-    encode_batch_fn: Callable[[List[str]], List[str]],
+    encode_batch_fn: Callable[[List[str]], List[EncodingT]],
     token_budget_batches_fn: Callable[[List[str], int], Iterator[Any]],
     encoding_size: int,
-) -> List[str]:
+) -> List[EncodingT]:
     """Encode amino acid sequences to 3Di tokens.
 
     This is a standalone encoding function that orchestrates the encoding pipeline.

--- a/src/genome_entropy/encode3di/modernprost.py
+++ b/src/genome_entropy/encode3di/modernprost.py
@@ -9,18 +9,17 @@ Multi-GPU support uses HuggingFace accelerate library.
 
 import inspect
 import sys
-import time
 from collections.abc import Mapping
 from typing import Any, Iterator, List, Optional, Sequence
 
 try:
     import torch
     import torch.nn.functional as F
-    from transformers import AutoModel, AutoTokenizer
-    from accelerate import Accelerator
 
     # Check transformers version for ModernBert support
     import transformers
+    from accelerate import Accelerator
+    from transformers import AutoModel, AutoTokenizer
 
     transformers_version = tuple(map(int, transformers.__version__.split(".")[:2]))
     if transformers_version < (5, 14):
@@ -577,19 +576,19 @@ class ModernProstThreeDiEncoder:
             EncodingError: If encoding fails
         """
         if use_multi_gpu:
-            # Use accelerate for multi-GPU encoding
-            if not self.use_accelerate:
-                # Need to re-initialize with accelerate support
-                logger.info(
-                    "Re-initializing encoder with accelerate for multi-GPU support"
-                )
-                self.__init__(
-                    model_name=self.model_name,
-                    device=None,
-                    use_accelerate=True,
-                )
+            from .multi_gpu import MultiGPUEncoder
 
-            self._load_model()
+            # Use pre-initialized encoder if provided, otherwise create new one
+            if multi_gpu_encoder is None:
+                logger.info("Initializing multi-GPU encoding")
+                multi_gpu_encoder = MultiGPUEncoder(
+                    model_name=self.model_name,
+                    encoder_class=ModernProstThreeDiEncoder,
+                    gpu_ids=gpu_ids,
+                )
+                logger.info("Loading models on all GPUs...")
+                for gpu_encoder in multi_gpu_encoder.encoders:
+                    gpu_encoder._load_model()
 
             # Preprocess sequences (ModernProst-specific, no ProstT5 prefix)
             processed_seqs = []
@@ -603,66 +602,12 @@ class ModernProstThreeDiEncoder:
                 )
                 processed_seqs.append(seq)
 
-            # Process in batches using accelerate
-            import math
-
-            total_sequences = len(processed_seqs)
-            total_batches = math.ceil(sum(map(len, processed_seqs)) / encoding_size)
-
-            # Create batches
-            batches = list(self.token_budget_batches(processed_seqs, encoding_size))
-
-            # Process all batches with accelerate
-            encodings: List[StructuralEncoding | None] = [None] * total_sequences
-
-            from .encoding import format_seconds, get_memory_info
-
-            t0 = time.perf_counter()
-            avg_batch_sec: float | None = None
-
-            for idx, batch in enumerate(batches, start=1):
-                batch_seqs = [x.seq for x in batch]
-                batch_idxs = [x.idx for x in batch]
-
-                # Calculate ETA
-                remaining = total_batches - (idx - 1)
-                eta_str = (
-                    "--"
-                    if avg_batch_sec is None
-                    else format_seconds(avg_batch_sec * remaining)
-                )
-
-                # Get memory info
-                allocated, reserved = get_memory_info()
-
-                logger.info(
-                    "3Di encoding batch %d of %d batches. "
-                    "Estimated %s remaining. Cuda memory allocated: %.1f GB reserved: %.1f GB",
-                    idx,
-                    total_batches,
-                    eta_str,
-                    allocated,
-                    reserved,
-                )
-
-                batch_start = time.perf_counter()
-                batch_results = self._encode_batch(batch_seqs)
-
-                # Store results in original order
-                for bi, br in zip(batch_idxs, batch_results):
-                    encodings[bi] = br
-
-                # Update timing
-                batch_elapsed = time.perf_counter() - batch_start
-                if idx == 1:
-                    avg_batch_sec = batch_elapsed
-                else:
-                    elapsed_total = time.perf_counter() - t0
-                    avg_batch_sec = elapsed_total / idx
-
-            if any(value is None for value in encodings):
-                raise ModelError("ModernProst failed to encode every input sequence")
-            return [value for value in encodings if value is not None]
+            return multi_gpu_encoder.encode_multi_gpu(
+                processed_seqs,
+                self.token_budget_batches,
+                encoding_size,
+                skip_model_loading=True,
+            )
         else:
             # Use single-GPU encoding
             self._load_model()

--- a/src/genome_entropy/encode3di/modernprost.py
+++ b/src/genome_entropy/encode3di/modernprost.py
@@ -3,11 +3,14 @@
 This module implements an encoder for gbouras13/modernprost models,
 adapted from the phold implementation.
 
-Note: ModernProst models require transformers >= 4.47.0 for ModernBert support.
+Note: The multitask ModernProst models require transformers >= 5.14.1.
 Multi-GPU support uses HuggingFace accelerate library.
 """
 
+import inspect
+import sys
 import time
+from collections.abc import Mapping
 from typing import Any, Iterator, List, Optional, Sequence
 
 try:
@@ -20,22 +23,21 @@ try:
     import transformers
 
     transformers_version = tuple(map(int, transformers.__version__.split(".")[:2]))
-    if transformers_version < (4, 47):
+    if transformers_version < (5, 14):
         import warnings
 
         warnings.warn(
-            f"ModernProst models require transformers >= 4.47.0 (current: {transformers.__version__}). "
-            "Please upgrade: pip install --upgrade 'transformers>=4.47.0'",
+            f"ModernProst models require transformers >= 5.14.1 (current: {transformers.__version__}). "
+            "Please upgrade: pip install --upgrade 'transformers>=5.14.1'",
             UserWarning,
         )
-except ImportError as e:
+except ImportError:
     torch = None  # type: ignore[assignment]
     AutoModel = None  # type: ignore[assignment,misc]
     AutoTokenizer = None  # type: ignore[assignment,misc]
     F = None  # type: ignore[assignment,misc]
     Accelerator = None  # type: ignore[assignment,misc]
 
-import numpy as np
 from pathlib import Path
 
 from ..config import (
@@ -44,15 +46,30 @@ from ..config import (
     CUDA_DEVICE,
     DEFAULT_ENCODING_SIZE,
     MPS_DEVICE,
-    MODERNPROST_PROFILES_MODEL,
+    THREEDDI_ALPHABET_ORDERED,
+    TWELVE_STATE_ALPHABET_ORDERED,
+    get_model_capabilities,
+    resolve_model_name,
 )
 from ..errors import DeviceError, ModelError
 from ..logging_config import get_logger
 from ..translate.translator import ProteinRecord
-from .encoding import encode
-from .types import IndexedSeq, ThreeDiRecord
+from .types import IndexedSeq, StructuralEncoding, ThreeDiRecord
 
 logger = get_logger(__name__)
+
+
+def _enable_remote_code_sibling_imports(config: Any) -> None:
+    """Expose the trusted remote-code directory for an absolute sibling import.
+
+    The multitask repository currently imports its configuration module without
+    a relative prefix. Transformers caches trusted remote code in a package, so
+    that import otherwise cannot resolve even though the file was downloaded.
+    """
+    module_path = Path(inspect.getfile(config.__class__)).parent
+    module_path_string = str(module_path)
+    if module_path_string not in sys.path:
+        sys.path.append(module_path_string)
 
 
 def _is_model_cached(model_name: str) -> bool:
@@ -65,7 +82,6 @@ def _is_model_cached(model_name: str) -> bool:
         True if model is cached, False otherwise
     """
     try:
-        from transformers.utils import TRANSFORMERS_CACHE
         from huggingface_hub import try_to_load_from_cache
 
         # Try to find the model in the cache
@@ -88,10 +104,10 @@ def _is_model_cached(model_name: str) -> bool:
 
 
 class ModernProstThreeDiEncoder:
-    """Encoder for converting amino acid sequences to 3Di structural tokens.
+    """Encoder for converting proteins to structural-state tokens.
 
-    Uses ModernProst models (gbouras13/modernprost-base or modernprost-profiles)
-    from HuggingFace to predict 3Di tokens directly from protein sequences.
+    Multitask models predict paired 3Di and 12-state sequences, while deprecated
+    models retain the tensor-only 3Di output API.
 
     Based on implementation from phold:
     https://github.com/gbouras13/phold/blob/main/src/phold/features/predict_3Di.py
@@ -106,7 +122,7 @@ class ModernProstThreeDiEncoder:
         """Initialize the ModernProst encoder.
 
         Args:
-            model_name: HuggingFace model identifier (gbouras13/modernprost-base or modernprost-profiles)
+            model_name: A supported Hugging Face model identifier.
             device: Device to use ("cuda", "mps", "cpu", or None for auto-detect)
             use_accelerate: If True, use HuggingFace accelerate for multi-GPU support
 
@@ -120,7 +136,15 @@ class ModernProstThreeDiEncoder:
                 "Install with: pip install torch transformers"
             )
 
-        self.model_name = model_name
+        self.model_name = resolve_model_name(model_name)
+        self.capabilities = get_model_capabilities(self.model_name, warn=False)
+        if self.capabilities.family == "prostt5":
+            raise ModelError(f"{self.model_name} is not a ModernProst model")
+        if self.capabilities.deprecated:
+            logger.warning(
+                "The selected model is deprecated and produces only 3Di output. "
+                "twelve_state and twelve_state_entropy will be null."
+            )
         self.use_accelerate = use_accelerate
         self.accelerator: Any = None
 
@@ -221,6 +245,8 @@ class ModernProstThreeDiEncoder:
                 local_files_only=is_cached,
                 force_download=not is_cached,
             )
+            if self.capabilities.supports_12st:
+                _enable_remote_code_sibling_imports(config)
 
             # Disable torch.compile if supported (ModernBert has this option)
             if hasattr(config, "reference_compile"):
@@ -261,7 +287,13 @@ class ModernProstThreeDiEncoder:
 
             self.model = self.model.eval()
 
-            logger.info("Loaded model %s on device %s", self.model_name, self.device)
+            logger.info(
+                "Loaded %s: 3Di=%s, 12-state=%s (device=%s)",
+                self.model_name,
+                "yes" if self.capabilities.supports_3di else "no",
+                "yes" if self.capabilities.supports_12st else "no",
+                self.device,
+            )
             logger.debug("Model config:\n%s", self.model.config)
         except Exception as e:
             logger.error("Failed to load ModernProst model %s: %s", self.model_name, e)
@@ -393,7 +425,51 @@ class ModernProstThreeDiEncoder:
             if batch:
                 yield batch
 
-    def _encode_batch(self, aa_sequences: List[str]) -> List[str]:
+    def _decode_head(
+        self,
+        logits: Any,
+        attention_mask: Any,
+        lengths: Sequence[int],
+        alphabet: str,
+        expected_classes: int,
+        head_name: str,
+    ) -> List[str]:
+        """Validate and decode a residue-level classifier head."""
+        if getattr(logits, "ndim", None) != 3:
+            raise ModelError(
+                f"{self.model_name} {head_name} logits must have shape B x L x "
+                f"{expected_classes}; got {getattr(logits, 'shape', None)}"
+            )
+        if logits.shape[-1] != expected_classes:
+            raise ModelError(
+                f"{self.model_name} {head_name} head has {logits.shape[-1]} classes; "
+                f"expected {expected_classes}"
+            )
+        if logits.shape[:2] != attention_mask.shape:
+            raise ModelError(
+                f"{self.model_name} {head_name} logits shape {tuple(logits.shape[:2])} "
+                f"does not match attention mask {tuple(attention_mask.shape)}"
+            )
+        if logits.shape[0] != len(lengths):
+            raise ModelError(
+                f"{self.model_name} returned {logits.shape[0]} {head_name} rows for "
+                f"{len(lengths)} proteins"
+            )
+
+        predictions = logits.argmax(dim=-1).detach().cpu()
+        masks = attention_mask.detach().cpu().bool()
+        decoded = []
+        for row, mask, expected_length in zip(predictions, masks, lengths):
+            class_ids = row[mask].tolist()
+            if len(class_ids) != expected_length:
+                raise ModelError(
+                    f"{self.model_name} tokenizer produced {len(class_ids)} residue "
+                    f"positions for a protein of length {expected_length}"
+                )
+            decoded.append("".join(alphabet[int(index)] for index in class_ids))
+        return decoded
+
+    def _encode_batch(self, aa_sequences: List[str]) -> List[StructuralEncoding]:
         """
         Encode a batch of sequences using ModernProst.
 
@@ -425,50 +501,57 @@ class ModernProstThreeDiEncoder:
 
         # Run inference
         with torch.no_grad():
-            outputs = self.model(
-                token_encoding.input_ids,
-                attention_mask=token_encoding.attention_mask,
+            outputs = self.model(**token_encoding)
+
+        logits = outputs.logits
+        if self.capabilities.supports_12st:
+            if not isinstance(logits, Mapping):
+                raise ModelError(
+                    f"{self.model_name} is declared dual-head but outputs.logits "
+                    "is not a mapping"
+                )
+            missing = {"3di", "12st"} - set(logits)
+            if missing:
+                raise ModelError(
+                    f"{self.model_name} output is missing required head(s): "
+                    f"{', '.join(sorted(missing))}"
+                )
+            logits_3di = logits["3di"]
+            logits_12st = logits["12st"]
+        else:
+            if isinstance(logits, Mapping):
+                raise ModelError(
+                    f"Legacy model {self.model_name} unexpectedly returned mapped logits"
+                )
+            logits_3di = logits
+            logits_12st = None
+
+        three_di = self._decode_head(
+            logits_3di,
+            token_encoding.attention_mask,
+            seq_lens,
+            THREEDDI_ALPHABET_ORDERED,
+            20,
+            "3di",
+        )
+        twelve_state: List[str | None] = []
+        if logits_12st is not None:
+            decoded_twelve_state = self._decode_head(
+                logits_12st,
+                token_encoding.attention_mask,
+                seq_lens,
+                TWELVE_STATE_ALPHABET_ORDERED,
+                12,
+                "12st",
             )
+            twelve_state.extend(decoded_twelve_state)
+        else:
+            twelve_state = [None] * len(three_di)
 
-        # Extract logits and compute predictions
-        logits = outputs.logits  # [B, L, C]
-
-        # Get predictions (argmax over classes)
-        preds = torch.argmax(logits, dim=-1)  # [B, L]
-        preds_cpu = preds.cpu().numpy()
-
-        # Map predictions to 3Di alphabet
-        ss_mapping = {
-            0: "A",
-            1: "C",
-            2: "D",
-            3: "E",
-            4: "F",
-            5: "G",
-            6: "H",
-            7: "I",
-            8: "K",
-            9: "L",
-            10: "M",
-            11: "N",
-            12: "P",
-            13: "Q",
-            14: "R",
-            15: "S",
-            16: "T",
-            17: "V",
-            18: "W",
-            19: "Y",
-        }
-
-        # Convert predictions to 3Di strings
-        structure_sequences = []
-        for batch_idx, s_len in enumerate(seq_lens):
-            pred = preds_cpu[batch_idx, :s_len]
-            three_di = "".join([ss_mapping[int(p)] for p in pred])
-            structure_sequences.append(three_di)
-
-        return structure_sequences
+        return [
+            StructuralEncoding(three_di=three, twelve_state=twelve)
+            for three, twelve in zip(three_di, twelve_state)
+        ]
 
     def encode(
         self,
@@ -477,7 +560,7 @@ class ModernProstThreeDiEncoder:
         use_multi_gpu: bool = False,
         gpu_ids: Optional[List[int]] = None,
         multi_gpu_encoder: Optional[Any] = None,
-    ) -> List[str]:
+    ) -> List[StructuralEncoding]:
         """Encode amino acid sequences to 3Di tokens.
 
         Args:
@@ -530,7 +613,7 @@ class ModernProstThreeDiEncoder:
             batches = list(self.token_budget_batches(processed_seqs, encoding_size))
 
             # Process all batches with accelerate
-            three_di_sequences: List[str] = [None] * total_sequences  # type: ignore[list-item]
+            encodings: List[StructuralEncoding | None] = [None] * total_sequences
 
             from .encoding import format_seconds, get_memory_info
 
@@ -567,7 +650,7 @@ class ModernProstThreeDiEncoder:
 
                 # Store results in original order
                 for bi, br in zip(batch_idxs, batch_results):
-                    three_di_sequences[bi] = br
+                    encodings[bi] = br
 
                 # Update timing
                 batch_elapsed = time.perf_counter() - batch_start
@@ -577,7 +660,9 @@ class ModernProstThreeDiEncoder:
                     elapsed_total = time.perf_counter() - t0
                     avg_batch_sec = elapsed_total / idx
 
-            return three_di_sequences
+            if any(value is None for value in encodings):
+                raise ModelError("ModernProst failed to encode every input sequence")
+            return [value for value in encodings if value is not None]
         else:
             # Use single-GPU encoding
             self._load_model()
@@ -602,13 +687,13 @@ class ModernProstThreeDiEncoder:
             total_batches = math.ceil(sum(map(len, processed_seqs)) / encoding_size)
 
             # Create batches iterator
-            batches = self.token_budget_batches(processed_seqs, encoding_size)
+            batch_iterator = self.token_budget_batches(processed_seqs, encoding_size)
 
             # Process all batches
             from .encoding import process_batches
 
             return process_batches(
-                batches,
+                batch_iterator,
                 self._encode_batch,
                 total_sequences,
                 total_batches,
@@ -638,7 +723,7 @@ class ModernProstThreeDiEncoder:
         aa_sequences = [p.aa_sequence for p in proteins]
 
         # Encode
-        three_di_sequences = self.encode(
+        structural_encodings = self.encode(
             aa_sequences,
             encoding_size,
             use_multi_gpu=use_multi_gpu,
@@ -648,18 +733,30 @@ class ModernProstThreeDiEncoder:
 
         # Create records
         records = []
-        method = (
-            "modernprost_profiles"
-            if self.model_name == MODERNPROST_PROFILES_MODEL
-            else "modernprost_base"
-        )
-        for protein, three_di in zip(proteins, three_di_sequences):
+        method = self.capabilities.family
+        for protein, structural in zip(proteins, structural_encodings):
+            expected = len(protein.aa_sequence)
+            observed_3di = len(structural.three_di)
+            observed_12st = (
+                None
+                if structural.twelve_state is None
+                else len(structural.twelve_state)
+            )
+            if observed_3di != expected or (
+                self.capabilities.supports_12st and observed_12st != expected
+            ):
+                raise ModelError(
+                    f"Structural encoding length mismatch for {protein.orf.orf_id}: "
+                    f"expected={expected}, three_di={observed_3di}, "
+                    f"twelve_state={observed_12st}, model={self.model_name}"
+                )
             record = ThreeDiRecord(
                 protein=protein,
-                three_di=three_di,
+                three_di=structural.three_di,
                 method=method,
                 model_name=self.model_name,
                 inference_device=self.device,
+                twelve_state=structural.twelve_state,
             )
             records.append(record)
 

--- a/src/genome_entropy/encode3di/multi_gpu.py
+++ b/src/genome_entropy/encode3di/multi_gpu.py
@@ -88,7 +88,7 @@ class MultiGPUEncoder:
         self,
         encoder_idx: int,
         batch: List[IndexedSeq],
-    ) -> Tuple[List[int], List[str]]:
+    ) -> Tuple[List[int], List[Any]]:
         """Encode a single batch on a specific GPU asynchronously.
 
         Args:
@@ -125,7 +125,7 @@ class MultiGPUEncoder:
         self,
         batches: List[List[IndexedSeq]],
         total_sequences: int,
-    ) -> List[str]:
+    ) -> List[Any]:
         """Encode all batches across multiple GPUs asynchronously.
 
         Args:
@@ -138,7 +138,7 @@ class MultiGPUEncoder:
         Raises:
             EncodingError: If encoding fails
         """
-        three_di_sequences: List[str] = [None] * total_sequences  # type: ignore[list-item]
+        encodings: List[Any | None] = [None] * total_sequences
 
         t0 = time.perf_counter()
         total_batches = len(batches)
@@ -150,13 +150,6 @@ class MultiGPUEncoder:
             len(self.encoders),
         )
 
-        # Create a shared queue for all batches
-        batch_queue: asyncio.Queue[Tuple[int, List[IndexedSeq]]] = asyncio.Queue()
-
-        # Enqueue all batches with their indices
-        for batch_idx, batch in enumerate(batches):
-            await batch_queue.put((batch_idx, batch))
-
         # Track completed batches and errors
         completed = 0
         completed_lock = asyncio.Lock()
@@ -166,16 +159,10 @@ class MultiGPUEncoder:
             """Worker coroutine that processes batches for a specific GPU."""
             nonlocal completed, first_error
 
-            while True:
-                try:
-                    # Get next batch from queue (non-blocking check)
-                    batch_idx, batch = await asyncio.wait_for(
-                        batch_queue.get(), timeout=0.1
-                    )
-                except asyncio.TimeoutError:
-                    # Queue is empty, exit worker
-                    break
-
+            # Assign batches round-robin so each device has one worker and a
+            # fast device cannot consume work intended for every other device.
+            for batch_idx in range(gpu_idx, total_batches, len(self.encoders)):
+                batch = batches[batch_idx]
                 try:
                     # Encode the batch on this GPU
                     batch_idxs, batch_results = await self.encode_batch_async(
@@ -184,7 +171,7 @@ class MultiGPUEncoder:
 
                     # Store results in original order
                     for bi, br in zip(batch_idxs, batch_results):
-                        three_di_sequences[bi] = br
+                        encodings[bi] = br
 
                     # Update progress
                     async with completed_lock:
@@ -202,9 +189,6 @@ class MultiGPUEncoder:
                             eta_remaining,
                         )
 
-                    # Mark task as done
-                    batch_queue.task_done()
-
                 except Exception as e:
                     # Store first error and stop processing
                     if first_error is None:
@@ -216,7 +200,6 @@ class MultiGPUEncoder:
                             e,
                             exc_info=True,
                         )
-                    batch_queue.task_done()
                     break
 
         # Create one worker per GPU
@@ -244,7 +227,7 @@ class MultiGPUEncoder:
             ) from first_error
 
         # Check all sequences encoded
-        missing = [i for i, v in enumerate(three_di_sequences) if v is None]
+        missing = [i for i, value in enumerate(encodings) if value is None]
         if missing:
             raise RuntimeError(
                 f"Missing encodings for {len(missing)} sequences "
@@ -259,7 +242,7 @@ class MultiGPUEncoder:
             total_sequences / elapsed_total if elapsed_total > 0 else 0,
         )
 
-        return three_di_sequences
+        return encodings
 
     def encode_multi_gpu(
         self,
@@ -267,7 +250,7 @@ class MultiGPUEncoder:
         token_budget_batches_fn: Callable[[List[str], int], Iterator[Any]],
         encoding_size: int,
         skip_model_loading: bool = False,
-    ) -> List[str]:
+    ) -> List[Any]:
         """Encode sequences using multiple GPUs.
 
         This is a synchronous wrapper around the async encoding method.
@@ -311,7 +294,7 @@ class MultiGPUEncoder:
         self,
         batches: List[List[IndexedSeq]],
         total_sequences: int,
-    ) -> List[str]:
+    ) -> List[Any]:
         """Fallback to sequential single-GPU encoding.
 
         Args:
@@ -321,7 +304,7 @@ class MultiGPUEncoder:
         Returns:
             List of encoded 3Di sequences in original input order
         """
-        three_di_sequences: List[str] = [None] * total_sequences  # type: ignore[list-item]
+        encodings: List[Any | None] = [None] * total_sequences
         encoder = self.encoders[0]
 
         logger.info(
@@ -338,7 +321,7 @@ class MultiGPUEncoder:
             results = encoder._encode_batch(batch_seqs)
 
             for bi, br in zip(batch_idxs, results):
-                three_di_sequences[bi] = br
+                encodings[bi] = br
 
             elapsed = time.perf_counter() - t0
             avg_time = elapsed / batch_idx
@@ -353,8 +336,8 @@ class MultiGPUEncoder:
             )
 
         # Check all sequences encoded
-        missing = [i for i, v in enumerate(three_di_sequences) if v is None]
+        missing = [i for i, value in enumerate(encodings) if value is None]
         if missing:
             raise RuntimeError(f"Missing encodings for {len(missing)} sequences")
 
-        return three_di_sequences
+        return encodings

--- a/src/genome_entropy/encode3di/prostt5.py
+++ b/src/genome_entropy/encode3di/prostt5.py
@@ -6,10 +6,11 @@ that have been moved to separate modules for better organization.
 
 # For backward compatibility, re-export from new modules
 from .encoder import ProstT5ThreeDiEncoder
-from .types import IndexedSeq, ThreeDiRecord
+from .types import IndexedSeq, StructuralEncoding, ThreeDiRecord
 
 __all__ = [
     "ProstT5ThreeDiEncoder",
     "ThreeDiRecord",
+    "StructuralEncoding",
     "IndexedSeq",
 ]

--- a/src/genome_entropy/encode3di/types.py
+++ b/src/genome_entropy/encode3di/types.py
@@ -1,8 +1,6 @@
-"""Data types for 3Di encoding."""
+"""Data types for structural-state encoding."""
 
 from dataclasses import dataclass
-from typing import Literal
-
 from ..translate.translator import ProteinRecord
 
 
@@ -20,9 +18,18 @@ class ThreeDiRecord:
 
     protein: ProteinRecord
     three_di: str
-    method: Literal["prostt5_aa2fold"]
+    method: str
     model_name: str
     inference_device: str
+    twelve_state: str | None = None
+
+
+@dataclass(frozen=True)
+class StructuralEncoding:
+    """Associated structural encodings produced by one model forward pass."""
+
+    three_di: str
+    twelve_state: str | None
 
 
 @dataclass(frozen=True)

--- a/src/genome_entropy/entropy/shannon.py
+++ b/src/genome_entropy/entropy/shannon.py
@@ -27,6 +27,7 @@ class EntropyReport:
     protein_aa_entropy: Dict[str, float]
     three_di_entropy: Dict[str, float]
     alphabet_sizes: Dict[str, int]
+    twelve_state_entropy: Dict[str, float] | None = None
 
 
 def shannon_entropy(

--- a/src/genome_entropy/io/jsonio.py
+++ b/src/genome_entropy/io/jsonio.py
@@ -11,7 +11,7 @@ from ..logging_config import get_logger
 logger = get_logger(__name__)
 
 # Schema version for tracking output format changes
-SCHEMA_VERSION = "2.0.0"
+SCHEMA_VERSION = "2.1.0"
 
 
 def to_json_dict(obj: Any) -> Any:
@@ -90,6 +90,7 @@ def convert_pipeline_result_to_unified(pipeline_result):
         FeatureDNA,
         FeatureProtein,
         FeatureThreeDi,
+        FeatureTwelveState,
         FeatureMetadata,
         FeatureEntropy,
     )
@@ -136,6 +137,11 @@ def convert_pipeline_result_to_unified(pipeline_result):
         dna_entropy = result.entropy.orf_nt_entropy.get(orf_id, 0.0)
         protein_entropy = result.entropy.protein_aa_entropy.get(orf_id, 0.0)
         three_di_entropy = result.entropy.three_di_entropy.get(orf_id, 0.0)
+        twelve_state_entropy = (
+            None
+            if result.entropy.twelve_state_entropy is None
+            else result.entropy.twelve_state_entropy.get(orf_id)
+        )
 
         # Build the unified feature
         # Instead of storing the ORF object three times, we extract each
@@ -180,6 +186,15 @@ def convert_pipeline_result_to_unified(pipeline_result):
                 dna_entropy=dna_entropy,
                 protein_entropy=protein_entropy,
                 three_di_entropy=three_di_entropy,
+                twelve_state_entropy=twelve_state_entropy,
+            ),
+            twelve_state=(
+                None
+                if three_di_record.twelve_state is None
+                else FeatureTwelveState(
+                    encoding=three_di_record.twelve_state,
+                    length=len(three_di_record.twelve_state),
+                )
             ),
         )
 
@@ -197,7 +212,7 @@ def convert_pipeline_result_to_unified(pipeline_result):
 
     # Create the unified result with schema version for compatibility tracking
     unified_result = UnifiedPipelineResult(
-        schema_version=SCHEMA_VERSION,  # v2.0.0 for new unified format
+        schema_version=SCHEMA_VERSION,
         input_id=result.input_id,
         input_dna_length=result.input_dna_length,
         dna_entropy_global=result.entropy.dna_entropy_global,
@@ -237,7 +252,7 @@ def write_json(data: Any, output_path: Union[str, Path], indent: int = 2) -> Non
       - entropy.orf_nt_entropy[id] → features[id].entropy.dna_entropy
 
     NEW FORMAT adds:
-      - schema_version: "2.0.0" (for compatibility tracking)
+      - schema_version: "2.1.0" (for compatibility tracking)
       - features: dict (replaces orfs, proteins, three_dis lists)
       - Hierarchical organization (location, dna, protein, three_di, metadata, entropy)
 
@@ -320,6 +335,18 @@ def read_json(input_path: Union[str, Path]) -> Any:
 
     with open_func(input_path, mode, encoding="utf-8") as f:
         data = json.load(f)
+
+    # Schema 2.0 and older predate the optional 12-state representation.
+    records = data if isinstance(data, list) else [data]
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        for feature in record.get("features", {}).values():
+            feature.setdefault("twelve_state", None)
+            feature.setdefault("entropy", {}).setdefault("twelve_state_entropy", None)
+        for structural_record in record.get("three_dis", []):
+            structural_record.setdefault("twelve_state", None)
+        record.get("entropy", {}).setdefault("twelve_state_entropy", None)
 
     logger.info("Successfully read JSON file: %s", input_path)
     return data

--- a/src/genome_entropy/ml/classifier.py
+++ b/src/genome_entropy/ml/classifier.py
@@ -15,6 +15,25 @@ from ..logging_config import get_logger
 
 logger = get_logger(__name__)
 
+LEGACY_FEATURE_NAMES = [
+    "dna_entropy",
+    "protein_entropy",
+    "three_di_entropy",
+    "dna_length",
+    "protein_length",
+    "three_di_length",
+    "start",
+    "end",
+    "strand_plus",
+    "frame",
+    "has_start_codon",
+    "has_stop_codon",
+]
+FEATURE_NAMES = LEGACY_FEATURE_NAMES + [
+    "twelve_state_entropy",
+    "twelve_state_length",
+]
+
 
 def load_json_data(json_dir: Path) -> List[List[Dict[str, Any]]]:
     """Load all JSON files from a directory.
@@ -162,20 +181,7 @@ def extract_features(
     features_list = []
     labels_list = []
     metadata_list = [] if return_metadata else None
-    feature_names = [
-        "dna_entropy",
-        "protein_entropy",
-        "three_di_entropy",
-        "dna_length",
-        "protein_length",
-        "three_di_length",
-        "start",
-        "end",
-        "strand_plus",  # 1 if +, 0 if -
-        "frame",
-        "has_start_codon",
-        "has_stop_codon",
-    ]
+    feature_names = FEATURE_NAMES.copy()
 
     orf_count = 0
     for jd in json_data:
@@ -201,6 +207,17 @@ def extract_features(
                             float(feature["location"]["frame"]),
                             1.0 if feature["metadata"]["has_start_codon"] else 0.0,
                             1.0 if feature["metadata"]["has_stop_codon"] else 0.0,
+                            (
+                                np.nan
+                                if feature["entropy"].get("twelve_state_entropy")
+                                is None
+                                else feature["entropy"]["twelve_state_entropy"]
+                            ),
+                            (
+                                np.nan
+                                if feature.get("twelve_state") is None
+                                else feature["twelve_state"]["length"]
+                            ),
                         ]
 
                         # Extract label
@@ -238,6 +255,7 @@ def extract_features(
                 orf_nt_entropy = entropy.get("orf_nt_entropy", {})
                 protein_aa_entropy = entropy.get("protein_aa_entropy", {})
                 three_di_entropy = entropy.get("three_di_entropy", {})
+                twelve_state_entropy = entropy.get("twelve_state_entropy")
 
                 # Get proteins and three_dis by orf_id
                 proteins = {p["orf"]["orf_id"]: p for p in data.get("proteins", [])}
@@ -268,6 +286,16 @@ def extract_features(
                             float(orf["frame"]),
                             1.0 if orf["has_start_codon"] else 0.0,
                             1.0 if orf["has_stop_codon"] else 0.0,
+                            (
+                                np.nan
+                                if twelve_state_entropy is None
+                                else twelve_state_entropy.get(orf_id, np.nan)
+                            ),
+                            (
+                                np.nan
+                                if three_di.get("twelve_state") is None
+                                else len(three_di["twelve_state"])
+                            ),
                         ]
 
                         label = 1 if orf.get("in_genbank", False) else 0
@@ -433,7 +461,7 @@ class GenbankClassifier:
         if not self.is_trained:
             raise RuntimeError("Model not trained. Call fit() first.")
 
-        return self.model.predict(X)
+        return self.model.predict(self._align_feature_width(X))
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
         """Predict class probabilities.
@@ -447,7 +475,7 @@ class GenbankClassifier:
         if not self.is_trained:
             raise RuntimeError("Model not trained. Call fit() first.")
 
-        return self.model.predict_proba(X)
+        return self.model.predict_proba(self._align_feature_width(X))
 
     def evaluate(self, X: np.ndarray, y: np.ndarray) -> Dict[str, float]:
         """Evaluate the model on test data.
@@ -462,7 +490,29 @@ class GenbankClassifier:
         if not self.is_trained:
             raise RuntimeError("Model not trained. Call fit() first.")
 
-        return self.model.evaluate(X, y)
+        return self.model.evaluate(self._align_feature_width(X), y)
+
+    def _align_feature_width(self, X: np.ndarray) -> np.ndarray:
+        """Retain compatibility with saved 12-feature classifiers."""
+        model = self.model
+        if model is None:
+            raise RuntimeError("Model not initialized")
+        if self.model_type == "xgboost":
+            expected = model.model.num_features()
+        else:
+            expected = model.input_dim
+        if X.shape[1] == expected:
+            return X
+        if expected == len(LEGACY_FEATURE_NAMES) and X.shape[1] == len(FEATURE_NAMES):
+            logger.warning(
+                "Loaded classifier uses the legacy feature schema; ignoring the "
+                "appended 12-state features for this model."
+            )
+            return X[:, :expected]
+        raise ValueError(
+            f"Classifier expects {expected} features but input has {X.shape[1]}; "
+            "the saved feature schema is incompatible"
+        )
 
     def get_feature_importance(self) -> Optional[Dict[str, float]]:
         """Get feature importance scores.
@@ -491,6 +541,8 @@ class GenbankClassifier:
             raise RuntimeError("Model not trained. Call fit() first.")
 
         self.model.save(path)
+        feature_path = Path(path).with_suffix(Path(path).suffix + ".features.json")
+        feature_path.write_text(json.dumps(self.feature_names or []), encoding="utf-8")
         logger.info(f"Model saved to {path}")
 
     def load(self, path: Path) -> None:
@@ -513,5 +565,19 @@ class GenbankClassifier:
             raise ValueError(f"Unknown model_type: {self.model_type}")
 
         self.model.load(path)
+        feature_path = Path(path).with_suffix(Path(path).suffix + ".features.json")
+        if feature_path.exists():
+            self.feature_names = json.loads(feature_path.read_text(encoding="utf-8"))
+        else:
+            expected = (
+                self.model.model.num_features()
+                if self.model_type == "xgboost"
+                else self.model.input_dim
+            )
+            self.feature_names = (
+                LEGACY_FEATURE_NAMES.copy()
+                if expected == len(LEGACY_FEATURE_NAMES)
+                else None
+            )
         self.is_trained = True
         logger.info(f"Model loaded from {path}")

--- a/src/genome_entropy/ml/models.py
+++ b/src/genome_entropy/ml/models.py
@@ -421,6 +421,7 @@ class NeuralNetModel(BaseModel):
         self.learning_rate = learning_rate
         self.epochs = epochs
         self.batch_size = batch_size
+        self.imputation_values: Optional[np.ndarray] = None
 
         # Auto-detect device
         if device is None:
@@ -477,6 +478,19 @@ class NeuralNetModel(BaseModel):
         Returns:
             Dictionary with training metrics
         """
+        # Neural networks cannot consume NaN directly. Preserve NaN in extracted
+        # feature matrices, then fit and retain a column-median imputer here.
+        with np.errstate(all="ignore"):
+            self.imputation_values = np.nanmedian(X, axis=0)
+        if np.isnan(self.imputation_values).any():
+            logger.warning(
+                "Some classifier feature columns contain no observed values; "
+                "the neural-network imputer will use its explicit 0.0 fallback "
+                "for those all-missing columns."
+            )
+        self.imputation_values = np.nan_to_num(self.imputation_values, nan=0.0)
+        X = np.where(np.isnan(X), self.imputation_values, X)
+
         # Build model
         self.model = self._build_model().to(self.device)
 
@@ -568,6 +582,8 @@ class NeuralNetModel(BaseModel):
         if self.model is None:
             raise RuntimeError("Model not trained")
 
+        if self.imputation_values is not None:
+            X = np.where(np.isnan(X), self.imputation_values, X)
         self.model.eval()
         with self.torch.no_grad():
             X_t = self.torch.tensor(X, dtype=self.torch.float32).to(self.device)
@@ -588,6 +604,8 @@ class NeuralNetModel(BaseModel):
         if self.model is None:
             raise RuntimeError("Model not trained")
 
+        if self.imputation_values is not None:
+            X = np.where(np.isnan(X), self.imputation_values, X)
         self.model.eval()
         with self.torch.no_grad():
             X_t = self.torch.tensor(X, dtype=self.torch.float32).to(self.device)
@@ -661,6 +679,7 @@ class NeuralNetModel(BaseModel):
                 "learning_rate": self.learning_rate,
                 "epochs": self.epochs,
                 "batch_size": self.batch_size,
+                "imputation_values": self.imputation_values,
             },
             path,
         )
@@ -684,6 +703,7 @@ class NeuralNetModel(BaseModel):
         self.learning_rate = checkpoint.get("learning_rate", 0.001)
         self.epochs = checkpoint.get("epochs", 100)
         self.batch_size = checkpoint.get("batch_size", 32)
+        self.imputation_values = checkpoint.get("imputation_values")
 
         # Build and load model
         self.model = self._build_model().to(self.device)

--- a/src/genome_entropy/pipeline/__init__.py
+++ b/src/genome_entropy/pipeline/__init__.py
@@ -7,6 +7,7 @@ from .types import (
     FeatureDNA,
     FeatureProtein,
     FeatureThreeDi,
+    FeatureTwelveState,
     FeatureMetadata,
     FeatureEntropy,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "FeatureDNA",
     "FeatureProtein",
     "FeatureThreeDi",
+    "FeatureTwelveState",
     "FeatureMetadata",
     "FeatureEntropy",
 ]

--- a/src/genome_entropy/pipeline/runner.py
+++ b/src/genome_entropy/pipeline/runner.py
@@ -9,7 +9,10 @@ from ..config import (
     DEFAULT_MIN_AA_LENGTH,
     DEFAULT_PROSTT5_MODEL,
     DEFAULT_ENCODING_SIZE,
-    MODERNPROST_MODELS,
+    THREEDDI_ALPHABET_SIZE,
+    TWELVE_STATE_ALPHABET_SIZE,
+    get_model_capabilities,
+    resolve_model_name,
 )
 from ..encode3di.prostt5 import ProstT5ThreeDiEncoder, ThreeDiRecord
 from ..encode3di.modernprost import ModernProstThreeDiEncoder
@@ -113,6 +116,8 @@ def run_pipeline(
         logger.info("GenBank file: %s", genbank_file)
     logger.info("Genetic code table: %d", table_id)
     logger.info("Minimum AA length: %d", min_aa_len)
+    model_name = resolve_model_name(model_name)
+    capabilities = get_model_capabilities(model_name, warn=False)
     logger.info("Model: %s", model_name)
     logger.info("Compute entropy: %s", compute_entropy)
     if use_multi_gpu:
@@ -151,7 +156,7 @@ def run_pipeline(
         logger.info("Initializing 3Di encoder (model will be loaded on first use)...")
 
         # Select encoder based on model name
-        if model_name in MODERNPROST_MODELS:
+        if capabilities.family.startswith("modernprost"):
             encoder = ModernProstThreeDiEncoder(model_name=model_name, device=device)
             encoder_class = ModernProstThreeDiEncoder
         else:
@@ -215,6 +220,7 @@ def run_pipeline(
                     protein_aa_entropy={},
                     three_di_entropy={},
                     alphabet_sizes={},
+                    twelve_state_entropy=None,
                 )
                 results.append(
                     PipelineResult(
@@ -254,7 +260,7 @@ def run_pipeline(
                 gpu_ids=gpu_ids,
                 multi_gpu_encoder=multi_gpu_encoder,
             )
-            logger.info("Encoded %d 3Di sequence(s)", len(three_dis))
+            logger.info("Encoded %d structural-state sequence(s)", len(three_dis))
 
             # Step 5: Calculate entropy
             if compute_entropy:
@@ -271,6 +277,7 @@ def run_pipeline(
                     protein_aa_entropy={},
                     three_di_entropy={},
                     alphabet_sizes={},
+                    twelve_state_entropy=None,
                 )
 
             # Create result
@@ -336,11 +343,23 @@ def calculate_pipeline_entropy(
     three_di_sequences = {td.protein.orf.orf_id: td.three_di for td in three_dis}
     three_di_entropy = calculate_entropies_for_sequences(three_di_sequences)
 
+    twelve_state_sequences = {
+        td.protein.orf.orf_id: td.twelve_state
+        for td in three_dis
+        if td.twelve_state is not None
+    }
+    twelve_state_entropy = (
+        calculate_entropies_for_sequences(twelve_state_sequences)
+        if twelve_state_sequences
+        else None
+    )
+
     # Alphabet sizes
     alphabet_sizes = {
         "dna": 4,
         "protein": 20,
-        "three_di": 20,
+        "three_di": THREEDDI_ALPHABET_SIZE,
+        "twelve_state": TWELVE_STATE_ALPHABET_SIZE,
     }
 
     logger.debug("Entropy calculation complete")
@@ -351,4 +370,5 @@ def calculate_pipeline_entropy(
         protein_aa_entropy=protein_aa_entropy,
         three_di_entropy=three_di_entropy,
         alphabet_sizes=alphabet_sizes,
+        twelve_state_entropy=twelve_state_entropy,
     )

--- a/src/genome_entropy/pipeline/types.py
+++ b/src/genome_entropy/pipeline/types.py
@@ -79,6 +79,14 @@ class FeatureThreeDi:
 
 
 @dataclass
+class FeatureTwelveState:
+    """Optional 12-state structural encoding for a feature."""
+
+    encoding: str
+    length: int
+
+
+@dataclass
 class FeatureMetadata:
     """Metadata about a feature.
 
@@ -110,6 +118,7 @@ class FeatureEntropy:
     dna_entropy: float
     protein_entropy: float
     three_di_entropy: float
+    twelve_state_entropy: float | None = None
 
 
 @dataclass
@@ -138,6 +147,7 @@ class UnifiedFeature:
     three_di: FeatureThreeDi
     metadata: FeatureMetadata
     entropy: FeatureEntropy
+    twelve_state: FeatureTwelveState | None = None
 
 
 @dataclass

--- a/tests/test_estimate_tokens_model_selection.py
+++ b/tests/test_estimate_tokens_model_selection.py
@@ -6,10 +6,12 @@ import pytest
 def test_estimate_tokens_imports_modernprost() -> None:
     """Test that estimate_tokens command can import ModernProstThreeDiEncoder."""
     try:
-        from genome_entropy.cli.commands.estimate_tokens import estimate_token_size_command
+        from genome_entropy.cli.commands.estimate_tokens import (
+            estimate_token_size_command,
+        )
         from genome_entropy.encode3di import ModernProstThreeDiEncoder
         from genome_entropy.config import MODERNPROST_MODELS
-        
+
         # Verify imports work
         assert ModernProstThreeDiEncoder is not None
         assert MODERNPROST_MODELS is not None
@@ -21,37 +23,55 @@ def test_estimate_tokens_imports_modernprost() -> None:
 
 def test_model_selection_logic() -> None:
     """Test that correct encoder class is selected based on model name."""
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
     try:
-        from genome_entropy.encode3di import ProstT5ThreeDiEncoder, ModernProstThreeDiEncoder
-        from genome_entropy.config import MODERNPROST_MODELS
-        
+        from genome_entropy.encode3di import (
+            ModernProstThreeDiEncoder,
+            ProstT5ThreeDiEncoder,
+        )
+        from genome_entropy.config import (
+            MODERNPROST_BASE_DEPRECATED_MODEL,
+            MODERNPROST_MODELS,
+            MODERNPROST_PROFILES_DEPRECATED_MODEL,
+        )
+
         # Test model names
         prostt5_model = "Rostlab/ProstT5_fp16"
         modernprost_base = "gbouras13/modernprost-base"
         modernprost_profiles = "gbouras13/modernprost-profiles"
-        
+
         # Verify model detection logic (same as in estimate_tokens.py)
         assert modernprost_base in MODERNPROST_MODELS
         assert modernprost_profiles in MODERNPROST_MODELS
         assert prostt5_model not in MODERNPROST_MODELS
-        
+
         # Test encoder instantiation (without loading models)
         # ProstT5 encoder
         encoder_prostt5 = ProstT5ThreeDiEncoder(model_name=prostt5_model, device="cpu")
         assert encoder_prostt5.model_name == prostt5_model
         assert isinstance(encoder_prostt5, ProstT5ThreeDiEncoder)
         assert not isinstance(encoder_prostt5, ModernProstThreeDiEncoder)
-        
+
         # ModernProst base encoder
-        encoder_modernprost_base = ModernProstThreeDiEncoder(model_name=modernprost_base, device="cpu")
-        assert encoder_modernprost_base.model_name == modernprost_base
+        with pytest.warns(FutureWarning):
+            encoder_modernprost_base = ModernProstThreeDiEncoder(
+                model_name=modernprost_base, device="cpu"
+            )
+        assert encoder_modernprost_base.model_name == MODERNPROST_BASE_DEPRECATED_MODEL
         assert isinstance(encoder_modernprost_base, ModernProstThreeDiEncoder)
         assert not isinstance(encoder_modernprost_base, ProstT5ThreeDiEncoder)
-        
+
         # ModernProst profiles encoder
-        encoder_modernprost_profiles = ModernProstThreeDiEncoder(model_name=modernprost_profiles, device="cpu")
-        assert encoder_modernprost_profiles.model_name == modernprost_profiles
+        with pytest.warns(FutureWarning):
+            encoder_modernprost_profiles = ModernProstThreeDiEncoder(
+                model_name=modernprost_profiles, device="cpu"
+            )
+        assert (
+            encoder_modernprost_profiles.model_name
+            == MODERNPROST_PROFILES_DEPRECATED_MODEL
+        )
         assert isinstance(encoder_modernprost_profiles, ModernProstThreeDiEncoder)
-        
+
     except ImportError as e:
         pytest.skip(f"Required imports not available: {e}")

--- a/tests/test_file_split.py
+++ b/tests/test_file_split.py
@@ -231,7 +231,7 @@ def test_train_with_file_split(temp_json_dir_for_split):
         # Check training parameters
         assert result["training_parameters"]["model_type"] == "xgboost"
         assert result["training_parameters"]["random_seed"] == 42
-        assert result["training_parameters"]["n_features"] == 12
+        assert result["training_parameters"]["n_features"] == 14
 
         # Check metrics exist
         assert "accuracy" in result["test_metrics"]

--- a/tests/test_ml_classifier.py
+++ b/tests/test_ml_classifier.py
@@ -141,9 +141,7 @@ def test_load_multi_record_json_file(sample_json_unified, tmp_path):
     assert all(len(group) == 1 for group in data)
 
 
-def test_split_multi_record_json_keeps_records_together(
-    sample_json_unified, tmp_path
-):
+def test_split_multi_record_json_keeps_records_together(sample_json_unified, tmp_path):
     """Record-level splitting never divides one record's ORFs across sets."""
     records = []
     for i in range(10):
@@ -155,9 +153,7 @@ def test_split_multi_record_json_keeps_records_together(
     json_file.write_text(json.dumps(records))
     data = load_json_file(json_file)
 
-    train_data, test_data = split_json_records(
-        data, test_split=0.2, random_seed=123
-    )
+    train_data, test_data = split_json_records(data, test_split=0.2, random_seed=123)
     train_ids = {group[0]["input_id"] for group in train_data}
     test_ids = {group[0]["input_id"] for group in test_data}
 
@@ -186,9 +182,7 @@ def test_featureless_records_are_removed_before_record_split(
     json_file.write_text(json.dumps([empty_record, *usable_records]))
 
     data = filter_json_records_with_features(load_json_file(json_file))
-    train_data, test_data = split_json_records(
-        data, test_split=0.5, random_seed=42
-    )
+    train_data, test_data = split_json_records(data, test_split=0.5, random_seed=42)
 
     assert len(data) == 2
     assert len(train_data) == 1
@@ -234,11 +228,15 @@ def test_extract_features_unified_format(sample_json_unified):
 
     # Should have 2 ORFs
     assert X.shape[0] == 2
-    # Should have 12 features
-    assert X.shape[1] == 12
+    # Existing features remain ordered first; 12-state features are appended.
+    assert X.shape[1] == 14
 
     # Check feature names
-    assert len(feature_names) == 12
+    assert len(feature_names) == 14
+    assert "twelve_state_entropy" in feature_names
+    assert "twelve_state_length" in feature_names
+    assert np.isnan(X[0, feature_names.index("twelve_state_entropy")])
+    assert np.isnan(X[0, feature_names.index("twelve_state_length")])
     assert "dna_entropy" in feature_names
     assert "protein_entropy" in feature_names
     assert "three_di_entropy" in feature_names
@@ -338,7 +336,9 @@ def test_extract_features_old_format():
     X, y, feature_names, _ = extract_features([[old_format_data]])
 
     assert X.shape[0] == 1
-    assert X.shape[1] == 12
+    assert X.shape[1] == 14
+    assert np.isnan(X[0, feature_names.index("twelve_state_entropy")])
+    assert np.isnan(X[0, feature_names.index("twelve_state_length")])
     assert y[0] == 1
 
 

--- a/tests/test_modernprost_encoder.py
+++ b/tests/test_modernprost_encoder.py
@@ -84,13 +84,15 @@ def test_config_has_modernprost_models() -> None:
     """Test that config defines ModernProst model constants."""
     from genome_entropy.config import (
         MODERNPROST_BASE_MODEL,
+        MODERNPROST_BASE_DEPRECATED_MODEL,
         MODERNPROST_PROFILES_MODEL,
+        MODERNPROST_PROFILES_DEPRECATED_MODEL,
         MODERNPROST_MODELS,
     )
 
     # Check that constants are defined
-    assert MODERNPROST_BASE_MODEL == "gbouras13/modernprost-base"
-    assert MODERNPROST_PROFILES_MODEL == "gbouras13/modernprost-profiles"
+    assert MODERNPROST_BASE_MODEL == MODERNPROST_BASE_DEPRECATED_MODEL
+    assert MODERNPROST_PROFILES_MODEL == MODERNPROST_PROFILES_DEPRECATED_MODEL
     assert isinstance(MODERNPROST_MODELS, set)
     assert MODERNPROST_BASE_MODEL in MODERNPROST_MODELS
     assert MODERNPROST_PROFILES_MODEL in MODERNPROST_MODELS
@@ -115,7 +117,7 @@ def test_modernprost_encoder_instantiation() -> None:
     try:
         # Test that encoder can be instantiated (without loading model)
         encoder = ModernProstThreeDiEncoder(
-            model_name="gbouras13/modernprost-base", device="cpu"
+            model_name="gbouras13/modernprost-base-deprecated", device="cpu"
         )
 
         # Verify encoder has expected attributes
@@ -124,7 +126,7 @@ def test_modernprost_encoder_instantiation() -> None:
         assert hasattr(encoder, "model")
         assert hasattr(encoder, "tokenizer")
         assert encoder.device == "cpu"
-        assert encoder.model_name == "gbouras13/modernprost-base"
+        assert encoder.model_name == "gbouras13/modernprost-base-deprecated"
     except Exception:
         pytest.skip("Cannot instantiate encoder without dependencies")
 

--- a/tests/test_modernprost_multitask.py
+++ b/tests/test_modernprost_multitask.py
@@ -1,8 +1,8 @@
 """Focused tests for ModernProst model capabilities and dual-head decoding."""
 
+import json
 import math
 import os
-import json
 from contextlib import nullcontext
 from types import SimpleNamespace
 
@@ -24,8 +24,7 @@ from genome_entropy.config import (
     get_model_capabilities,
     resolve_model_name,
 )
-from genome_entropy.encode3di.types import IndexedSeq, StructuralEncoding
-from genome_entropy.encode3di.types import ThreeDiRecord
+from genome_entropy.encode3di.types import IndexedSeq, StructuralEncoding, ThreeDiRecord
 from genome_entropy.entropy.shannon import shannon_entropy
 from genome_entropy.errors import ModelError
 from genome_entropy.io.jsonio import read_json, to_json_dict
@@ -356,6 +355,96 @@ def test_multi_gpu_reordering_keeps_structural_encodings_together() -> None:
         2,
     )
     assert result == [expected["first"], expected["second"]]
+
+
+def test_modernprost_multi_gpu_reuses_prebuilt_manager(monkeypatch) -> None:
+    encoder = make_encoder(monkeypatch, MODERNPROST_50M_MODEL, {})
+
+    class Manager:
+        def __init__(self):
+            self.calls = []
+
+        def encode_multi_gpu(
+            self, aa_sequences, token_budget_batches_fn, encoding_size, skip_model_loading
+        ):
+            self.calls.append(
+                (
+                    aa_sequences,
+                    token_budget_batches_fn,
+                    encoding_size,
+                    skip_model_loading,
+                )
+            )
+            return [StructuralEncoding("AA", "BC")]
+
+    manager = Manager()
+    result = encoder.encode(
+        ["UB"],
+        encoding_size=17,
+        use_multi_gpu=True,
+        gpu_ids=[2, 3],
+        multi_gpu_encoder=manager,
+    )
+
+    assert result == [StructuralEncoding("AA", "BC")]
+    assert manager.calls == [(["XX"], encoder.token_budget_batches, 17, True)]
+
+
+def test_modernprost_multi_gpu_creates_manager_with_requested_gpu_ids(
+    monkeypatch,
+) -> None:
+    encoder = make_encoder(monkeypatch, MODERNPROST_50M_MODEL, {})
+
+    from genome_entropy.encode3di import multi_gpu as multi_gpu_module
+
+    captured = {}
+
+    class Loader:
+        def __init__(self):
+            self.load_calls = 0
+
+        def _load_model(self):
+            self.load_calls += 1
+
+    class FakeMultiGPUEncoder:
+        def __init__(self, model_name, encoder_class, gpu_ids=None):
+            captured["model_name"] = model_name
+            captured["encoder_class"] = encoder_class
+            captured["gpu_ids"] = gpu_ids
+            self.encoders = [Loader() for _ in gpu_ids]
+            captured["encoders"] = self.encoders
+
+        def encode_multi_gpu(
+            self, aa_sequences, token_budget_batches_fn, encoding_size, skip_model_loading
+        ):
+            captured["encode_args"] = (
+                aa_sequences,
+                token_budget_batches_fn,
+                encoding_size,
+                skip_model_loading,
+            )
+            return [StructuralEncoding("AA", "CD")]
+
+    monkeypatch.setattr(multi_gpu_module, "MultiGPUEncoder", FakeMultiGPUEncoder)
+
+    result = encoder.encode(
+        ["UZ"],
+        encoding_size=23,
+        use_multi_gpu=True,
+        gpu_ids=[4, 5],
+    )
+
+    assert result == [StructuralEncoding("AA", "CD")]
+    assert captured["model_name"] == MODERNPROST_50M_MODEL
+    assert captured["encoder_class"].__name__ == "ModernProstThreeDiEncoder"
+    assert captured["gpu_ids"] == [4, 5]
+    assert captured["encode_args"] == (
+        ["XX"],
+        encoder.token_budget_batches,
+        23,
+        True,
+    )
+    assert [loader.load_calls for loader in captured["encoders"]] == [1, 1]
 
 
 @pytest.mark.integration

--- a/tests/test_modernprost_multitask.py
+++ b/tests/test_modernprost_multitask.py
@@ -1,0 +1,380 @@
+"""Focused tests for ModernProst model capabilities and dual-head decoding."""
+
+import math
+import os
+import json
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from genome_entropy.config import (
+    DEFAULT_PROSTT5_MODEL,
+    MODEL_REGISTRY,
+    MODERNPROST_1B_MODEL,
+    MODERNPROST_50M_MODEL,
+    MODERNPROST_BASE_DEPRECATED_MODEL,
+    MODERNPROST_PROFILES_DEPRECATED_MODEL,
+    PROSTT5_FP16_MODEL,
+    PROSTT5_MODEL,
+    THREEDDI_ALPHABET_ORDERED,
+    TWELVE_STATE_ALPHABET,
+    TWELVE_STATE_ALPHABET_ORDERED,
+    get_model_capabilities,
+    resolve_model_name,
+)
+from genome_entropy.encode3di.types import IndexedSeq, StructuralEncoding
+from genome_entropy.encode3di.types import ThreeDiRecord
+from genome_entropy.entropy.shannon import shannon_entropy
+from genome_entropy.errors import ModelError
+from genome_entropy.io.jsonio import read_json, to_json_dict
+from genome_entropy.ml.classifier import extract_features
+from genome_entropy.orf.types import OrfRecord
+from genome_entropy.pipeline.runner import calculate_pipeline_entropy
+from genome_entropy.translate.translator import ProteinRecord
+
+
+class FakeTensor:
+    """Small NumPy-backed subset of the tensor API used by the decoder."""
+
+    def __init__(self, values):
+        self.values = np.asarray(values)
+
+    @property
+    def ndim(self):
+        return self.values.ndim
+
+    @property
+    def shape(self):
+        return self.values.shape
+
+    def argmax(self, dim=-1):
+        return FakeTensor(self.values.argmax(axis=dim))
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def bool(self):
+        return FakeTensor(self.values.astype(bool))
+
+    def tolist(self):
+        return self.values.tolist()
+
+    def __iter__(self):
+        return (FakeTensor(value) for value in self.values)
+
+    def __getitem__(self, key):
+        if isinstance(key, FakeTensor):
+            key = key.values
+        return FakeTensor(self.values[key])
+
+
+class FakeTorch:
+    class cuda:
+        @staticmethod
+        def is_available():
+            return False
+
+    class backends:
+        pass
+
+    @staticmethod
+    def no_grad():
+        return nullcontext()
+
+
+class FakeBatchEncoding(dict):
+    def __init__(self, mask):
+        input_ids = FakeTensor(np.zeros_like(mask))
+        attention_mask = FakeTensor(mask)
+        super().__init__(input_ids=input_ids, attention_mask=attention_mask)
+        self.input_ids = input_ids
+        self.attention_mask = attention_mask
+
+    def to(self, _device):
+        return self
+
+
+def logits_for_classes(class_ids, classes):
+    logits = np.full((*np.asarray(class_ids).shape, classes), -1.0)
+    for batch_index, row in enumerate(class_ids):
+        for residue_index, class_id in enumerate(row):
+            logits[batch_index, residue_index, class_id] = 1.0
+    return FakeTensor(logits)
+
+
+def make_encoder(monkeypatch, model_name, logits):
+    from genome_entropy.encode3di import modernprost as module
+
+    monkeypatch.setattr(module, "torch", FakeTorch)
+    monkeypatch.setattr(module, "AutoModel", object())
+    encoder = module.ModernProstThreeDiEncoder(model_name=model_name, device="cpu")
+    encoder.tokenizer = lambda sequences, **kwargs: FakeBatchEncoding(
+        [
+            [1] * len(sequence) + [0] * (max(map(len, sequences)) - len(sequence))
+            for sequence in sequences
+        ]
+    )
+
+    class Model:
+        def __init__(self):
+            self.kwargs = None
+
+        def __call__(self, **kwargs):
+            self.kwargs = kwargs
+            return SimpleNamespace(logits=logits)
+
+    encoder.model = Model()
+    return encoder
+
+
+def test_model_registry_and_default() -> None:
+    assert DEFAULT_PROSTT5_MODEL == MODERNPROST_50M_MODEL
+    assert get_model_capabilities(MODERNPROST_1B_MODEL).supports_12st
+    for name in (
+        MODERNPROST_BASE_DEPRECATED_MODEL,
+        MODERNPROST_PROFILES_DEPRECATED_MODEL,
+        PROSTT5_MODEL,
+        PROSTT5_FP16_MODEL,
+    ):
+        assert name in MODEL_REGISTRY
+        assert MODEL_REGISTRY[name].supports_3di
+        assert not MODEL_REGISTRY[name].supports_12st
+
+
+def test_old_modernprost_aliases_resolve_with_warning() -> None:
+    with pytest.warns(FutureWarning, match="was renamed"):
+        assert (
+            resolve_model_name("gbouras13/modernprost-base")
+            == MODERNPROST_BASE_DEPRECATED_MODEL
+        )
+
+
+def test_multitask_output_decodes_both_heads_and_padding(monkeypatch) -> None:
+    logits = {
+        "3di": logits_for_classes([[0, 19, 1], [2, 3, 4]], 20),
+        "12st": logits_for_classes([[0, 11, 5], [2, 3, 4]], 12),
+    }
+    encoder = make_encoder(monkeypatch, MODERNPROST_50M_MODEL, logits)
+
+    result = encoder._encode_batch(["AAA", "GG"])
+
+    assert result == [
+        StructuralEncoding("AYC", "ALF"),
+        StructuralEncoding("DE", "CD"),
+    ]
+    assert set(encoder.model.kwargs) == {"input_ids", "attention_mask"}
+    assert [len(item.three_di) for item in result] == [3, 2]
+    assert [len(item.twelve_state or "") for item in result] == [3, 2]
+
+
+@pytest.mark.parametrize(
+    ("logits", "message"),
+    [
+        ({"3di": logits_for_classes([[0]], 20)}, "12st"),
+        (
+            {
+                "3di": logits_for_classes([[0]], 19),
+                "12st": logits_for_classes([[0]], 12),
+            },
+            "expected 20",
+        ),
+        (
+            {
+                "3di": logits_for_classes([[0]], 20),
+                "12st": logits_for_classes([[0]], 11),
+            },
+            "expected 12",
+        ),
+    ],
+)
+def test_multitask_output_validation(monkeypatch, logits, message) -> None:
+    encoder = make_encoder(monkeypatch, MODERNPROST_50M_MODEL, logits)
+    with pytest.raises(ModelError, match=message):
+        encoder._encode_batch(["A"])
+
+
+def test_multitask_model_rejects_tensor_logits(monkeypatch) -> None:
+    encoder = make_encoder(
+        monkeypatch,
+        MODERNPROST_50M_MODEL,
+        logits_for_classes([[0]], 20),
+    )
+    with pytest.raises(ModelError, match="not a mapping"):
+        encoder._encode_batch(["A"])
+
+
+def test_legacy_modernprost_returns_no_twelve_state(monkeypatch) -> None:
+    encoder = make_encoder(
+        monkeypatch,
+        MODERNPROST_BASE_DEPRECATED_MODEL,
+        logits_for_classes([[0, 1]], 20),
+    )
+    assert encoder._encode_batch(["AA"]) == [StructuralEncoding("AC", None)]
+
+
+def test_ordered_alphabets_cover_every_class() -> None:
+    assert len(THREEDDI_ALPHABET_ORDERED) == 20
+    assert len(set(THREEDDI_ALPHABET_ORDERED)) == 20
+    assert TWELVE_STATE_ALPHABET_ORDERED == "ABCDEFGHIJKL"
+    assert len(TWELVE_STATE_ALPHABET) == 12
+
+
+def test_twelve_state_entropy_extremes() -> None:
+    assert shannon_entropy("AAAA") == 0.0
+    assert shannon_entropy(TWELVE_STATE_ALPHABET_ORDERED) == pytest.approx(
+        math.log2(12)
+    )
+    assert shannon_entropy(
+        TWELVE_STATE_ALPHABET_ORDERED,
+        alphabet=TWELVE_STATE_ALPHABET,
+        normalize=True,
+    ) == pytest.approx(1.0)
+
+
+def make_structural_record(twelve_state):
+    orf = OrfRecord(
+        parent_id="seq",
+        orf_id="orf1",
+        start=0,
+        end=12,
+        strand="+",
+        frame=0,
+        nt_sequence="ATGGCCGCCGCC",
+        aa_sequence="MAAA",
+        table_id=11,
+        has_start_codon=True,
+        has_stop_codon=False,
+    )
+    protein = ProteinRecord(orf=orf, aa_sequence="MAAA", aa_length=4)
+    return (
+        orf,
+        protein,
+        ThreeDiRecord(
+            protein=protein,
+            three_di="ACDE",
+            twelve_state=twelve_state,
+            method="modernprost_multitask",
+            model_name=MODERNPROST_50M_MODEL,
+            inference_device="cpu",
+        ),
+    )
+
+
+def test_new_and_legacy_records_serialize_stable_twelve_state_fields() -> None:
+    _orf, _protein, new_record = make_structural_record("ABCD")
+    _orf, _protein, legacy_record = make_structural_record(None)
+    assert to_json_dict(new_record)["twelve_state"] == "ABCD"
+    assert to_json_dict(legacy_record)["twelve_state"] is None
+
+
+def test_pipeline_entropy_reports_twelve_state_or_none() -> None:
+    orf, protein, new_record = make_structural_record("AABC")
+    report = calculate_pipeline_entropy(
+        orf.nt_sequence,
+        [orf],
+        [protein],
+        [new_record],
+    )
+    assert report.twelve_state_entropy == {
+        "orf1": pytest.approx(shannon_entropy("AABC"))
+    }
+    assert report.alphabet_sizes["twelve_state"] == 12
+
+    _orf, _protein, legacy_record = make_structural_record(None)
+    legacy_report = calculate_pipeline_entropy(
+        orf.nt_sequence,
+        [orf],
+        [protein],
+        [legacy_record],
+    )
+    assert legacy_report.twelve_state_entropy is None
+
+
+def test_read_json_backfills_older_twelve_state_fields(tmp_path) -> None:
+    path = tmp_path / "old.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "2.0.0",
+                "features": {"orf1": {"entropy": {"three_di_entropy": 0.0}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    loaded = read_json(path)
+    assert loaded["features"]["orf1"]["twelve_state"] is None
+    assert loaded["features"]["orf1"]["entropy"]["twelve_state_entropy"] is None
+
+
+def test_ml_features_include_twelve_state_values() -> None:
+    feature = {
+        "location": {"start": 0, "end": 12, "strand": "+", "frame": 0},
+        "dna": {"length": 12},
+        "protein": {"length": 4},
+        "three_di": {"length": 4},
+        "twelve_state": {"encoding": "ABCD", "length": 4},
+        "metadata": {
+            "has_start_codon": True,
+            "has_stop_codon": False,
+            "in_genbank": True,
+        },
+        "entropy": {
+            "dna_entropy": 1.0,
+            "protein_entropy": 0.8,
+            "three_di_entropy": 2.0,
+            "twelve_state_entropy": 1.5,
+        },
+    }
+    matrix, _labels, names, _metadata = extract_features(
+        [[{"schema_version": "2.1.0", "features": {"orf1": feature}}]]
+    )
+    assert matrix[0, names.index("twelve_state_entropy")] == pytest.approx(1.5)
+    assert matrix[0, names.index("twelve_state_length")] == pytest.approx(4)
+
+
+def test_multi_gpu_reordering_keeps_structural_encodings_together() -> None:
+    from genome_entropy.encode3di.multi_gpu import MultiGPUEncoder
+
+    expected = {
+        "first": StructuralEncoding("AAA", "BBB"),
+        "second": StructuralEncoding("CCC", "DDD"),
+    }
+
+    class Encoder:
+        def _encode_batch(self, sequences):
+            return [expected[sequence] for sequence in sequences]
+
+    manager = object.__new__(MultiGPUEncoder)
+    manager.encoders = [Encoder()]
+    result = manager._encode_single_gpu_sequential(
+        [[IndexedSeq(1, "second"), IndexedSeq(0, "first")]],
+        2,
+    )
+    assert result == [expected["first"], expected["second"]]
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    os.environ.get("RUN_HUGGINGFACE_INTEGRATION_TESTS") != "1",
+    reason="set RUN_HUGGINGFACE_INTEGRATION_TESTS=1 to download the 50M model",
+)
+def test_modernprost_50m_integration() -> None:
+    from genome_entropy.encode3di.modernprost import ModernProstThreeDiEncoder
+
+    sequence = "MLKRSLLFLTVLLLLFSFSSITNEVSASSSFDKGKY"
+    encoding = ModernProstThreeDiEncoder(
+        MODERNPROST_50M_MODEL,
+        device="cpu",
+    ).encode(
+        [sequence]
+    )[0]
+    assert len(encoding.three_di) == len(sequence)
+    assert encoding.twelve_state is not None
+    assert len(encoding.twelve_state) == len(sequence)
+    assert math.isfinite(shannon_entropy(encoding.three_di))
+    assert math.isfinite(shannon_entropy(encoding.twelve_state))

--- a/tests/test_unified_output.py
+++ b/tests/test_unified_output.py
@@ -105,7 +105,7 @@ def test_convert_pipeline_result_to_unified():
 
     # Verify top-level fields
     assert isinstance(unified, UnifiedPipelineResult)
-    assert unified.schema_version == "2.0.0"
+    assert unified.schema_version == "2.1.0"
     assert unified.input_id == "test_seq"
     assert unified.input_dna_length == 100
     assert unified.dna_entropy_global == 1.8
@@ -355,7 +355,7 @@ def test_unified_json_serialization():
 
     # Verify JSON structure
     assert "schema_version" in json_dict
-    assert json_dict["schema_version"] == "2.0.0"
+    assert json_dict["schema_version"] == "2.1.0"
     assert "input_id" in json_dict
     assert "input_dna_length" in json_dict
     assert "dna_entropy_global" in json_dict


### PR DESCRIPTION
## Summary

Updates genome_entropy for the new multitask ModernProst models.

- makes `gbouras13/modernprost-50M` the default;
- adds the larger `gbouras13/modernprost` model;
- predicts both 3Di and 12-state structural encodings in one forward pass;
- calculates entropy for both representations;
- retains deprecated ModernProst and ProstT5 models as 3Di-only options;
- serializes unsupported 12-state values as `null`;
- preserves loading of existing JSON output;
- adds 12-state features to the machine-learning data pipeline.

## Compatibility

Legacy models continue to produce 3Di output. For those models:

- `twelve_state` is `null`;
- `twelve_state_entropy` is `null`.

Existing JSON files without the new fields remain readable. Old ModernProst repository names transparently resolve to their renamed `-deprecated` repositories with a deprecation warning, while output provenance records the repository actually loaded.

## Tests

- `PYTHONPATH=/tmp/genome-entropy-hf:/tmp/genome-entropy-test-deps:src /tmp/genome-entropy-test-deps/bin/pytest -q`: 205 passed, 14 skipped.
- `RUN_HUGGINGFACE_INTEGRATION_TESTS=1 ... pytest -q tests/test_modernprost_multitask.py::test_modernprost_50m_integration -s`: 1 passed.
- `PYTHONPATH=/tmp/genome-entropy-devtools python -m black --check src tests`: passed.
- `ruff check src tests`: 28 pre-existing errors remain (baseline main: 36).
- `mypy src/genome_entropy`: repository baseline remains non-clean (72 errors on main; 72 on this branch with the same dependency-aware invocation).

## Model validation

Validated `gbouras13/modernprost-50M` on CPU with the requested 120-residue sequence through both the raw dual-head model API and the public encoder:

- raw head dimensions: 3Di = 20 classes, 12-state = 12 classes;
- encoded lengths: 3Di = 120, 12-state = 120;
- 3Di entropy = 3.0095433570550285;
- 12-state entropy = 2.72546414022261.

The published model currently uses an absolute sibling import in its trusted remote code. The encoder and download command include a narrow cache-directory compatibility shim, verified by the integration test.