### PR TITLE
Correct ModernProst 1B model repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The documentation includes:
 - 🔄 **Translation**: Convert ORFs to protein sequences with support for all NCBI genetic code tables
 - 🏗️ **Structural-state encoding**: Predict 3Di and, with multitask ModernProst models, 12-state tokens directly from protein sequences
   - ModernProst 50M (`gbouras13/modernprost-50M`) - Default lightweight multitask model
-  - ModernProst 1B (`gbouras13/modernprost`) - Larger multitask model
+  - ModernProst 1B (`gbouras13/modernprost-base`) - Larger multitask model
   - Deprecated ModernProst models - Legacy 3Di-only models
   - ProstT5 (Rostlab/ProstT5) - Original model, full precision
   - ProstT5 fp16 (Rostlab/ProstT5_fp16) - Original model, half precision
@@ -113,7 +113,7 @@ genome_entropy run --input input.fasta --output results.json
 
 # Larger approximately 1B-parameter multitask model
 genome_entropy run --input input.fasta --output results.json \
-    --model gbouras13/modernprost
+    --model gbouras13/modernprost-base
 
 # Deprecated legacy 3Di-only model
 genome_entropy run --input input.fasta --output results.json \
@@ -129,7 +129,7 @@ genome_entropy run --input input.fasta --output results.json \
 | Model | Parameters | 3Di | 12-state | Status |
 |-------|-----------:|----:|---------:|--------|
 | `gbouras13/modernprost-50M` | approximately 50M | yes | yes | default |
-| `gbouras13/modernprost` | approximately 1B | yes | yes | supported |
+| `gbouras13/modernprost-base` | approximately 1B | yes | yes | supported |
 | `gbouras13/modernprost-base-deprecated` | legacy | yes | no | deprecated |
 | `gbouras13/modernprost-profiles-deprecated` | legacy | yes | no | deprecated |
 | `Rostlab/ProstT5` | legacy | yes | no | supported |
@@ -284,7 +284,7 @@ genome_entropy run \
 - `--min-aa`: Minimum protein length in amino acids (default: 30)
 - `--model, -m`: Model name (default: `gbouras13/modernprost-50M`)
   - `gbouras13/modernprost-50M` - Lightweight 3Di + 12-state model
-  - `gbouras13/modernprost` - Approximately 1B-parameter 3Di + 12-state model
+  - `gbouras13/modernprost-base` - Approximately 1B-parameter 3Di + 12-state model
   - `gbouras13/modernprost-base-deprecated` - Deprecated legacy 3Di-only model
   - `gbouras13/modernprost-profiles-deprecated` - Deprecated legacy profile-capable 3Di-only model
   - `Rostlab/ProstT5` - Original ProstT5 model
@@ -368,7 +368,7 @@ genome_entropy download
 
 # Download ModernProst models
 genome_entropy download --model gbouras13/modernprost-50M
-genome_entropy download --model gbouras13/modernprost
+genome_entropy download --model gbouras13/modernprost-base
 genome_entropy download --model gbouras13/modernprost-base-deprecated
 genome_entropy download --model gbouras13/modernprost-profiles-deprecated
 ```

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -76,7 +76,7 @@ Run the complete pipeline from DNA to 3Di with entropy analysis.
    Default: gbouras13/modernprost-50M
 
    Supported models include the multitask ``gbouras13/modernprost-50M`` and
-   ``gbouras13/modernprost`` models, both deprecated ModernProst repositories,
+   ``gbouras13/modernprost-base`` models, both deprecated ModernProst repositories,
    and both ProstT5 repositories.
 
 ``--device, -d TEXT``
@@ -238,7 +238,7 @@ both 3Di and 12-state encodings; legacy models produce only 3Di.
    Default: gbouras13/modernprost-50M
 
    Supported models include ``gbouras13/modernprost-50M``,
-   ``gbouras13/modernprost``, the two ``-deprecated`` ModernProst repositories,
+   ``gbouras13/modernprost-base``, the two ``-deprecated`` ModernProst repositories,
    ``Rostlab/ProstT5``, and ``Rostlab/ProstT5_fp16``.
 
 ``--device, -d TEXT``

--- a/src/genome_entropy/cli/commands/encode3di.py
+++ b/src/genome_entropy/cli/commands/encode3di.py
@@ -68,7 +68,7 @@ def encode3di_command(
 
     Available models:
     - gbouras13/modernprost-50M (default; 3Di and 12-state)
-    - gbouras13/modernprost (larger; 3Di and 12-state)
+    - gbouras13/modernprost-base (larger; 3Di and 12-state)
     - gbouras13/modernprost-base-deprecated (legacy 3Di only)
     - gbouras13/modernprost-profiles-deprecated (legacy 3Di only)
     - Rostlab/ProstT5 (original ProstT5 model, full precision)

--- a/src/genome_entropy/config.py
+++ b/src/genome_entropy/config.py
@@ -10,11 +10,12 @@ DEFAULT_MIN_NT_LENGTH = 90
 DEFAULT_MIN_AA_LENGTH = 30
 
 MODERNPROST_50M_MODEL = "gbouras13/modernprost-50M"
-MODERNPROST_1B_MODEL = "gbouras13/modernprost"
+MODERNPROST_1B_MODEL = "gbouras13/modernprost-base"
 MODERNPROST_BASE_DEPRECATED_MODEL = "gbouras13/modernprost-base-deprecated"
 MODERNPROST_PROFILES_DEPRECATED_MODEL = "gbouras13/modernprost-profiles-deprecated"
-# Backward-compatible constant imports now point at the renamed repositories.
-MODERNPROST_BASE_MODEL = MODERNPROST_BASE_DEPRECATED_MODEL
+# Backward-compatible constant imports use the current base model and the
+# renamed legacy profiles repository respectively.
+MODERNPROST_BASE_MODEL = MODERNPROST_1B_MODEL
 MODERNPROST_PROFILES_MODEL = MODERNPROST_PROFILES_DEPRECATED_MODEL
 PROSTT5_MODEL = "Rostlab/ProstT5"
 PROSTT5_FP16_MODEL = "Rostlab/ProstT5_fp16"
@@ -84,7 +85,6 @@ MODEL_REGISTRY: Dict[str, ModelCapabilities] = {
 }
 
 MODEL_ALIASES = {
-    "gbouras13/modernprost-base": MODERNPROST_BASE_DEPRECATED_MODEL,
     "gbouras13/modernprost-profiles": MODERNPROST_PROFILES_DEPRECATED_MODEL,
 }
 

--- a/tests/test_estimate_tokens_model_selection.py
+++ b/tests/test_estimate_tokens_model_selection.py
@@ -31,7 +31,6 @@ def test_model_selection_logic() -> None:
             ProstT5ThreeDiEncoder,
         )
         from genome_entropy.config import (
-            MODERNPROST_BASE_DEPRECATED_MODEL,
             MODERNPROST_MODELS,
             MODERNPROST_PROFILES_DEPRECATED_MODEL,
         )
@@ -53,12 +52,11 @@ def test_model_selection_logic() -> None:
         assert isinstance(encoder_prostt5, ProstT5ThreeDiEncoder)
         assert not isinstance(encoder_prostt5, ModernProstThreeDiEncoder)
 
-        # ModernProst base encoder
-        with pytest.warns(FutureWarning):
-            encoder_modernprost_base = ModernProstThreeDiEncoder(
-                model_name=modernprost_base, device="cpu"
-            )
-        assert encoder_modernprost_base.model_name == MODERNPROST_BASE_DEPRECATED_MODEL
+        # ModernProst base encoder is the current 1B multitask model.
+        encoder_modernprost_base = ModernProstThreeDiEncoder(
+            model_name=modernprost_base, device="cpu"
+        )
+        assert encoder_modernprost_base.model_name == modernprost_base
         assert isinstance(encoder_modernprost_base, ModernProstThreeDiEncoder)
         assert not isinstance(encoder_modernprost_base, ProstT5ThreeDiEncoder)
 

--- a/tests/test_modernprost_encoder.py
+++ b/tests/test_modernprost_encoder.py
@@ -84,14 +84,14 @@ def test_config_has_modernprost_models() -> None:
     """Test that config defines ModernProst model constants."""
     from genome_entropy.config import (
         MODERNPROST_BASE_MODEL,
-        MODERNPROST_BASE_DEPRECATED_MODEL,
+        MODERNPROST_1B_MODEL,
         MODERNPROST_PROFILES_MODEL,
         MODERNPROST_PROFILES_DEPRECATED_MODEL,
         MODERNPROST_MODELS,
     )
 
     # Check that constants are defined
-    assert MODERNPROST_BASE_MODEL == MODERNPROST_BASE_DEPRECATED_MODEL
+    assert MODERNPROST_BASE_MODEL == MODERNPROST_1B_MODEL
     assert MODERNPROST_PROFILES_MODEL == MODERNPROST_PROFILES_DEPRECATED_MODEL
     assert isinstance(MODERNPROST_MODELS, set)
     assert MODERNPROST_BASE_MODEL in MODERNPROST_MODELS

--- a/tests/test_modernprost_multitask.py
+++ b/tests/test_modernprost_multitask.py
@@ -134,6 +134,7 @@ def make_encoder(monkeypatch, model_name, logits):
 
 def test_model_registry_and_default() -> None:
     assert DEFAULT_PROSTT5_MODEL == MODERNPROST_50M_MODEL
+    assert MODERNPROST_1B_MODEL == "gbouras13/modernprost-base"
     assert get_model_capabilities(MODERNPROST_1B_MODEL).supports_12st
     for name in (
         MODERNPROST_BASE_DEPRECATED_MODEL,
@@ -146,11 +147,11 @@ def test_model_registry_and_default() -> None:
         assert not MODEL_REGISTRY[name].supports_12st
 
 
-def test_old_modernprost_aliases_resolve_with_warning() -> None:
+def test_old_profiles_alias_resolves_with_warning() -> None:
     with pytest.warns(FutureWarning, match="was renamed"):
         assert (
-            resolve_model_name("gbouras13/modernprost-base")
-            == MODERNPROST_BASE_DEPRECATED_MODEL
+            resolve_model_name("gbouras13/modernprost-profiles")
+            == MODERNPROST_PROFILES_DEPRECATED_MODEL
         )
 
 


### PR DESCRIPTION
## Summary

Corrects the supported repository name for the approximately 1B-parameter multitask model.

- changes `MODERNPROST_1B_MODEL` from `gbouras13/modernprost` to `gbouras13/modernprost-base`;
- treats `gbouras13/modernprost-base` as the canonical dual-head model rather than a legacy alias;
- keeps `gbouras13/modernprost-base-deprecated` as the separate deprecated 3Di-only repository;
- retains aliasing of the old `gbouras13/modernprost-profiles` name to `gbouras13/modernprost-profiles-deprecated`;
- updates CLI help, examples, model tables, and model-selection tests.

## Validation

- `pytest -q tests/test_modernprost_multitask.py tests/test_modernprost_encoder.py tests/test_estimate_tokens_model_selection.py tests/test_cli_smoke.py`: 42 passed, 2 skipped.
- Black check passed for all affected Python files.
- `git diff --check`: passed.