### PR TITLE
Add downstream entropy normalisation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,12 @@ also read protein FASTA files (`.fasta`, `.fa`, `.faa`) directly. Add
 Compute Shannon entropy at all representation levels:
 
 ```bash
-genome_entropy entropy --input 3di.json --output entropy.json --normalize
+genome_entropy entropy --input 3di.json --output entropy.json
 ```
+
+Entropy output is always raw Shannon entropy. Normalise it downstream when
+needed with the helpers in `genome_entropy.entropy`; normalised values are
+derived data and are not stored in standard JSON.
 
 ### `genome_entropy download` - Pre-download Models
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -337,11 +337,6 @@ Calculate Shannon entropy at all representation levels.
 ``--output, -o PATH``
    Output JSON file with entropy report
 
-**Optional Options:**
-
-``--normalize``
-   Normalize entropy by alphabet size (scale to [0, 1])
-
 **Examples:**
 
 .. code-block:: bash
@@ -349,11 +344,9 @@ Calculate Shannon entropy at all representation levels.
    # Calculate entropy
    genome_entropy entropy --input 3di.json --output entropy.json
 
-   # Calculate normalized entropy
-   genome_entropy entropy \
-       --input 3di.json \
-       --output entropy.json \
-       --normalize
+The command writes raw Shannon entropy. Use the normalisation helpers described
+in the user guide during downstream analysis; normalised entropy is not written
+to standard JSON.
 
 download
 ^^^^^^^^
@@ -658,7 +651,7 @@ Step-by-Step Analysis
        --device cuda
 
    # Step 4: Calculate entropy
-   genome_entropy entropy --input 3di.json --output entropy.json --normalize
+   genome_entropy entropy --input 3di.json --output entropy.json
 
 Optimizing Performance
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -166,20 +166,51 @@ Examples:
    # Intermediate
    "AAAACCCC" → H = 1.0 bits
 
-Normalized Entropy
+Normalised Entropy
 ^^^^^^^^^^^^^^^^^^
 
-Normalized entropy scales values to [0, 1] by dividing by the maximum possible entropy:
+Raw entropy is the value calculated and stored by ``genome_entropy``. Normalised
+entropy is completely derived from raw entropy and scales it by the maximum
+possible entropy of the theoretical alphabet:
 
 .. code-block:: text
 
    H_norm = H / log₂(|alphabet|)
 
-This allows fair comparison across different alphabets:
+Use these theoretical alphabet sizes in downstream analyses:
 
 * DNA: 4 symbols (max entropy = 2.0)
-* Protein: 20 symbols (max entropy ≈ 4.32)
-* 3Di: 20 symbols (max entropy ≈ 4.32)
+* Protein: 20 symbols (max entropy ≈ 4.3219)
+* 3Di: 20 symbols (max entropy ≈ 4.3219)
+* 12-state: 12 symbols (max entropy ≈ 3.5850)
+
+Standard JSON contains only raw entropy. Storing both forms would be redundant
+and could allow them to become inconsistent. Calculate normalised values only
+when a downstream analysis needs them:
+
+.. code-block:: python
+
+   from genome_entropy.entropy import (
+       normalise_dna_entropy,
+       normalise_protein_entropy,
+       normalise_three_di_entropy,
+       normalise_twelve_state_entropy,
+   )
+
+   dna_normalised = normalise_dna_entropy(feature["entropy"]["dna_entropy"])
+   protein_normalised = normalise_protein_entropy(
+       feature["entropy"]["protein_entropy"]
+   )
+   three_di_normalised = normalise_three_di_entropy(
+       feature["entropy"]["three_di_entropy"]
+   )
+   twelve_state_normalised = normalise_twelve_state_entropy(
+       feature["entropy"]["twelve_state_entropy"]
+   )
+
+The generic ``normalise_entropy(raw_entropy, alphabet_size)`` helper is also
+available. All helpers preserve ``None`` for missing values. They are not called
+automatically for ORFs and their results are not serialised.
 
 Entropy in Biology
 ^^^^^^^^^^^^^^^^^^

--- a/src/genome_entropy/cli/commands/entropy.py
+++ b/src/genome_entropy/cli/commands/entropy.py
@@ -23,12 +23,6 @@ def entropy_command(
         "-o",
         help="Output JSON file with entropy report",
     ),
-    normalize: bool = typer.Option(
-        False,
-        "--normalize",
-        "-n",
-        help="Normalize entropy by alphabet size",
-    ),
 ) -> None:
     """Calculate Shannon entropy at all representation levels.
 
@@ -41,10 +35,6 @@ def entropy_command(
         from ...translate.translator import ProteinRecord
         from ...encode3di.prostt5 import ThreeDiRecord
         from ...config import (
-            AA_ALPHABET,
-            DNA_ALPHABET,
-            THREEDDI_ALPHABET,
-            TWELVE_STATE_ALPHABET,
             THREEDDI_ALPHABET_SIZE,
             TWELVE_STATE_ALPHABET_SIZE,
         )
@@ -76,7 +66,7 @@ def entropy_command(
 
         typer.echo(f"  Loaded {len(three_dis)} 3Di record(s)")
 
-        typer.echo(f"\nCalculating entropy...")
+        typer.echo("\nCalculating entropy...")
 
         # Calculate entropies at different levels
         orf_nt_seqs = {
@@ -92,21 +82,11 @@ def entropy_command(
             if td.twelve_state is not None
         }
 
-        orf_nt_entropy = calculate_entropies_for_sequences(
-            orf_nt_seqs, alphabet=DNA_ALPHABET, normalize=normalize
-        )
-        protein_aa_entropy = calculate_entropies_for_sequences(
-            protein_aa_seqs, alphabet=AA_ALPHABET, normalize=normalize
-        )
-        three_di_entropy = calculate_entropies_for_sequences(
-            three_di_seqs, alphabet=THREEDDI_ALPHABET, normalize=normalize
-        )
+        orf_nt_entropy = calculate_entropies_for_sequences(orf_nt_seqs)
+        protein_aa_entropy = calculate_entropies_for_sequences(protein_aa_seqs)
+        three_di_entropy = calculate_entropies_for_sequences(three_di_seqs)
         twelve_state_entropy = (
-            calculate_entropies_for_sequences(
-                twelve_state_seqs,
-                alphabet=TWELVE_STATE_ALPHABET,
-                normalize=normalize,
-            )
+            calculate_entropies_for_sequences(twelve_state_seqs)
             if twelve_state_seqs
             else None
         )

--- a/src/genome_entropy/entropy/__init__.py
+++ b/src/genome_entropy/entropy/__init__.py
@@ -1,1 +1,17 @@
-"""Entropy calculation utilities."""
+"""Entropy calculation and downstream normalisation utilities."""
+
+from .shannon import (
+    normalise_dna_entropy,
+    normalise_entropy,
+    normalise_protein_entropy,
+    normalise_three_di_entropy,
+    normalise_twelve_state_entropy,
+)
+
+__all__ = [
+    "normalise_entropy",
+    "normalise_dna_entropy",
+    "normalise_protein_entropy",
+    "normalise_three_di_entropy",
+    "normalise_twelve_state_entropy",
+]

--- a/src/genome_entropy/entropy/shannon.py
+++ b/src/genome_entropy/entropy/shannon.py
@@ -9,6 +9,55 @@ from ..logging_config import get_logger
 
 logger = get_logger(__name__)
 
+DNA_ALPHABET_SIZE = 4
+PROTEIN_ALPHABET_SIZE = 20
+THREE_DI_ALPHABET_SIZE = 20
+TWELVE_STATE_ALPHABET_SIZE = 12
+
+
+def normalise_entropy(entropy: float | None, alphabet_size: int) -> float | None:
+    """Normalise a raw Shannon entropy using its theoretical alphabet size.
+
+    This helper is intended for downstream analysis. Normalised values are
+    derived from raw entropy and are therefore not stored in standard output.
+
+    Args:
+        entropy: Raw Shannon entropy in bits, or ``None`` for missing data.
+        alphabet_size: The theoretical number of symbols in the representation.
+
+    Returns:
+        Entropy divided by ``log2(alphabet_size)``, or ``None`` when entropy is
+        ``None``.
+
+    Raises:
+        ValueError: If ``alphabet_size`` is not greater than one.
+    """
+    if entropy is None:
+        return None
+    if alphabet_size <= 1:
+        raise ValueError("alphabet_size must be greater than 1")
+    return entropy / math.log2(alphabet_size)
+
+
+def normalise_dna_entropy(entropy: float | None) -> float | None:
+    """Normalise raw DNA entropy using the theoretical four-symbol alphabet."""
+    return normalise_entropy(entropy, DNA_ALPHABET_SIZE)
+
+
+def normalise_protein_entropy(entropy: float | None) -> float | None:
+    """Normalise raw protein entropy using the theoretical 20-symbol alphabet."""
+    return normalise_entropy(entropy, PROTEIN_ALPHABET_SIZE)
+
+
+def normalise_three_di_entropy(entropy: float | None) -> float | None:
+    """Normalise raw 3Di entropy using the theoretical 20-symbol alphabet."""
+    return normalise_entropy(entropy, THREE_DI_ALPHABET_SIZE)
+
+
+def normalise_twelve_state_entropy(entropy: float | None) -> float | None:
+    """Normalise raw 12-state entropy using its theoretical alphabet."""
+    return normalise_entropy(entropy, TWELVE_STATE_ALPHABET_SIZE)
+
 
 @dataclass
 class EntropyReport:

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -8,8 +8,35 @@ from genome_entropy.entropy.shannon import (
     EntropyReport,
     calculate_entropies_for_sequences,
     calculate_sequence_entropy,
+    normalise_dna_entropy,
+    normalise_entropy,
+    normalise_protein_entropy,
+    normalise_three_di_entropy,
+    normalise_twelve_state_entropy,
     shannon_entropy,
 )
+
+
+def test_normalise_entropy() -> None:
+    """Raw entropy is normalised using the theoretical alphabet size."""
+    assert normalise_entropy(1.0, 4) == pytest.approx(0.5)
+    assert normalise_entropy(math.log2(12), 12) == pytest.approx(1.0)
+    assert normalise_entropy(None, 20) is None
+
+
+@pytest.mark.parametrize("alphabet_size", [1, 0, -1])
+def test_normalise_entropy_rejects_invalid_alphabet_size(alphabet_size: int) -> None:
+    with pytest.raises(ValueError, match="greater than 1"):
+        normalise_entropy(1.0, alphabet_size)
+
+
+def test_representation_normalisation_wrappers() -> None:
+    """Representation wrappers use fixed theoretical alphabet sizes."""
+    assert normalise_dna_entropy(2.0) == pytest.approx(1.0)
+    assert normalise_protein_entropy(math.log2(20)) == pytest.approx(1.0)
+    assert normalise_three_di_entropy(math.log2(20)) == pytest.approx(1.0)
+    assert normalise_twelve_state_entropy(math.log2(12)) == pytest.approx(1.0)
+    assert normalise_twelve_state_entropy(None) is None
 
 
 def test_shannon_entropy_empty_string() -> None:


### PR DESCRIPTION
## Summary

- add a generic downstream entropy normalisation helper
- add representation-specific wrappers for DNA, protein, 3Di, and 12-state entropy
- ensure the entropy CLI and standard JSON output contain raw Shannon entropy only
- document theoretical alphabet sizes and downstream helper usage

## Why

Normalised entropy is fully derived from raw entropy and the theoretical alphabet size. Storing both forms is redundant and risks inconsistencies, so normalisation should happen explicitly during downstream analysis.

## User impact

Users can import the helpers from `genome_entropy.entropy`. The `entropy --normalize` output mode has been removed; standard JSON consistently stores raw entropy.

## Validation

- `PYTHONPATH=src pytest -q tests/test_entropy.py` — 16 passed
- `python -m ruff check src/genome_entropy/entropy src/genome_entropy/cli/commands/entropy.py tests/test_entropy.py` — passed
- `git diff --check` — passed

The broader ModernProst test module could not collect in the current environment because `PyGeneticCode` is not installed.
