### PR TITLE
Fix GenBank ORF matching when CDS translations contain X

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ genome_entropy download --model gbouras13/modernprost-50M
 # DNA FASTA to unified JSON
 genome_entropy run --input genome.fasta --output results.json
 
-# GenBank input also assigns in_genbank by C-terminal CDS matching
+# GenBank matching accepts aligned ambiguous X residues in C-terminal suffixes
 genome_entropy run --genbank genome.gbk.gz --output results.json
 
 # Protein FASTA directly to structural-state records

--- a/docs/source/data_formats.rst
+++ b/docs/source/data_formats.rst
@@ -84,17 +84,27 @@ When GenBank annotations are supplied, CDS features are extracted with Biopython
 and compared to called ORFs on the same parent sequence and strand. The current
 matcher:
 
-* compares strand-aware biological stop coordinates (``end`` on ``+`` and
-  ``start`` on ``-``), allowing an absolute difference of at most three bases;
+* requires equal strand-aware biological stop coordinates (``end`` on ``+`` and
+  ``start`` on ``-`` after converting Biopython coordinates);
 * strips terminal ``*`` symbols from both translations;
 * ignores the first amino acid before sequence comparison, accommodating start
   codon differences;
-* accepts equal C-terminal suffixes and truncated C-terminal subset matches when
-  the shorter compared sequence is at least 10 amino acids.
+* accepts compatible C-terminal suffixes and truncated C-terminal subset
+  matches;
+* treats ``X`` as an unknown residue compatible with any aligned amino-acid
+  symbol, while all other unequal pairs remain mismatches. ``B``, ``Z``, and
+  ``J`` are not treated as wildcards, and internal ``*`` symbols are invalid.
 
 ``in_genbank=True`` therefore means this heuristic matched an annotated CDS. It
 does not require exact full-length identity and does not establish biological
 function. Missing GenBank annotation input leaves the field false.
+
+CDS matching uses the supplied ``/translation`` qualifier. CDS features without
+that qualifier cannot currently match. Compound and origin-spanning locations
+are parsed by Biopython, but origin-spanning biological stop coordinates are not
+yet handled specially. Partial markers, ``codon_start``, translation exceptions,
+pseudogenes, and frameshifts are not reinterpreted by the matcher; their effect
+must already be represented in the supplied translation and location.
 
 .. _raw-and-normalised-entropy:
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -87,3 +87,11 @@ it does not prove the ORF is non-coding. Conversely, ``True`` is a heuristic
 annotation match, not a functional assignment. ML predictions learn this label
 and inherit its biases. Use genome- or file-level splits to estimate transfer to
 unseen records and read :doc:`ml` before reporting results.
+
+The GenBank heuristic requires the same parent, strand, and biological stop,
+then compares C-terminal suffixes after ignoring each protein's first residue.
+An aligned ``X`` is compatible with a specific residue, but unrelated mismatches
+and internal or N-terminal-only similarity remain disallowed. For nucleotide
+translation, multiply-resolvable IUPAC codons such as ``AAN`` and ``NNN`` become
+``X``; ambiguities with one translation, such as ``GCN`` (alanine), retain that
+specific amino acid.

--- a/src/genome_entropy/io/genbank.py
+++ b/src/genome_entropy/io/genbank.py
@@ -12,6 +12,8 @@ from ..orf.types import OrfRecord
 
 logger = get_logger(__name__)
 
+VALID_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWYBJZUOX")
+
 
 @dataclass
 class GenBankCDS:
@@ -158,12 +160,47 @@ def extract_cds_features(genbank_path: Union[str, Path]) -> List[GenBankCDS]:
     return cds_features
 
 
+def normalise_protein_sequence(sequence: str) -> str:
+    """Normalise a protein for GenBank matching.
+
+    Whitespace is removed, residues are upper-cased, and one terminal stop
+    marker is stripped. An internal stop marker makes the sequence invalid for
+    matching and is represented by an empty result.
+    """
+    normalised = "".join(sequence.split()).upper().removesuffix("*")
+    return "" if "*" in normalised else normalised
+
+
+def amino_acids_are_compatible(residue_a: str, residue_b: str) -> bool:
+    """Return whether two aligned protein residues are compatible.
+
+    Equal valid residues match. ``X`` is an unknown-residue wildcard, but the
+    more specific ambiguity symbols ``B``, ``Z``, and ``J`` are not themselves
+    wildcards. ``U`` and ``O`` are also treated as specific residues.
+    """
+    if residue_a not in VALID_AMINO_ACIDS or residue_b not in VALID_AMINO_ACIDS:
+        return False
+    return residue_a == residue_b or residue_a == "X" or residue_b == "X"
+
+
+def compatible_c_terminal_suffix(shorter: str, longer: str) -> bool:
+    """Return whether ``shorter`` compatibly aligns to the end of ``longer``."""
+    if not shorter or len(shorter) > len(longer):
+        return False
+
+    longer_tail = longer[-len(shorter) :]
+    return all(
+        amino_acids_are_compatible(shorter_residue, longer_residue)
+        for shorter_residue, longer_residue in zip(shorter, longer_tail)
+    )
+
+
 def orf_matches_genbank_cds(orf: OrfRecord, cds: GenBankCDS) -> bool:
-    """Match proteins by their strand-aware stop and exact C-terminal sequence.
+    """Match proteins by strand-aware stop and compatible C-terminal sequence.
 
     C-terminal matching recognises partial CDS translations and alternative
-    initiation residues without treating internal or N-terminal similarity as
-    evidence that two proteins are the same.
+    initiation residues. ``X`` is compatible with any valid amino-acid symbol
+    at an aligned position; all other unequal residues remain mismatches.
     """
     if orf.parent_id != cds.parent_id or orf.strand != cds.strand:
         return False
@@ -176,12 +213,8 @@ def orf_matches_genbank_cds(orf: OrfRecord, cds: GenBankCDS) -> bool:
     if orf_stop != cds_stop:
         return False
 
-    def normalise(sequence: str) -> str:
-        normalised = "".join(sequence.split()).upper()
-        return normalised.removesuffix("*")
-
-    orf_c_terminal = normalise(orf.aa_sequence)[1:]
-    cds_c_terminal = normalise(cds.protein_sequence)[1:]
+    orf_c_terminal = normalise_protein_sequence(orf.aa_sequence)[1:]
+    cds_c_terminal = normalise_protein_sequence(cds.protein_sequence)[1:]
     if not orf_c_terminal or not cds_c_terminal:
         return False
 
@@ -189,7 +222,27 @@ def orf_matches_genbank_cds(orf: OrfRecord, cds: GenBankCDS) -> bool:
         (orf_c_terminal, cds_c_terminal),
         key=len,
     )
-    return longer.endswith(shorter)
+    matches = compatible_c_terminal_suffix(shorter, longer)
+    if not matches and len(shorter) <= len(longer):
+        longer_tail = longer[-len(shorter) :]
+        for position, (shorter_residue, longer_residue) in enumerate(
+            zip(shorter, longer_tail),
+            start=1,
+        ):
+            if not amino_acids_are_compatible(shorter_residue, longer_residue):
+                logger.debug(
+                    "ORF %s and CDS at %s:%d-%d share a stop coordinate but "
+                    "differ at aligned residue %d: %s versus %s",
+                    orf.orf_id,
+                    cds.parent_id,
+                    cds.start,
+                    cds.end,
+                    position,
+                    shorter_residue,
+                    longer_residue,
+                )
+                break
+    return matches
 
 
 def match_orf_to_genbank_cds(

--- a/src/genome_entropy/translate/translator.py
+++ b/src/genome_entropy/translate/translator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import List
 
 import PyGeneticCode
+from Bio.Seq import Seq
 
 from ..config import DEFAULT_GENETIC_CODE_TABLE
 from ..errors import TranslationError
@@ -41,8 +42,10 @@ def translate_orf(
 ) -> ProteinRecord:
     """Translate an ORF to a protein sequence.
 
-    Uses the pygenetic-code library for translation with NCBI genetic codes.
-    Ambiguous codons (containing N or other IUPAC codes) are translated to 'X'.
+    Uses pygenetic-code for unambiguous DNA and Biopython for sequences that
+    contain IUPAC ambiguity codes. This prevents a multiply-resolvable codon
+    such as ``AAN`` or ``NNN`` from being assigned an arbitrary amino acid while
+    preserving specific translations for resolvable codons such as ``GCN``.
 
     Args:
         orf: OrfRecord to translate
@@ -64,25 +67,34 @@ def translate_orf(
 
     try:
 
-        # Translate sequence
-        aa_sequence = PyGeneticCode.translate(orf.nt_sequence, table_id)
+        # pygenetic-code 0.20 can resolve some ambiguous codons arbitrarily
+        # (for example AAN and NNN as lysine). Biopython implements the IUPAC
+        # semantics needed when ambiguity codes are present.
+        nucleotide_sequence = orf.nt_sequence.upper()
+        if set(nucleotide_sequence) <= set("ACGT"):
+            aa_sequence = PyGeneticCode.translate(nucleotide_sequence, table_id)
+        else:
+            aa_sequence = str(Seq(nucleotide_sequence).translate(table=table_id))
 
         if aa_sequence != orf.aa_sequence:
-            warning_message = f"""
-            Translated amino acid sequence is not the same as read from the file:
-            Provided:
-            {orf.aa_sequence}
-            Translated:
-            {aa_sequence}
-            DNA sequence:
-            {orf.nt_sequence}
-            Location:
-            Start: {orf.start} Stop: {orf.end} Frame: {orf.frame} Strand: {orf.strand}
-            """
+            first_difference = next(
+                (
+                    index
+                    for index, (provided, translated) in enumerate(
+                        zip(orf.aa_sequence, aa_sequence),
+                        start=1,
+                    )
+                    if provided != translated
+                ),
+                min(len(orf.aa_sequence), len(aa_sequence)) + 1,
+            )
             logger.warning(
-                "Translation mismatch for ORF %s; using translated sequence.%s",
+                "Translation mismatch for ORF %s; using translated sequence "
+                "(provided length=%d, translated length=%d, first difference=%d)",
                 orf.orf_id,
-                warning_message,
+                len(orf.aa_sequence),
+                len(aa_sequence),
+                first_difference,
             )
 
         # Remove stop codon (*) if present at the end

--- a/tests/test_genbank.py
+++ b/tests/test_genbank.py
@@ -8,6 +8,8 @@ import pytest
 
 from genome_entropy.io.genbank import (
     GenBankCDS,
+    amino_acids_are_compatible,
+    compatible_c_terminal_suffix,
     extract_cds_features,
     match_orf_to_genbank_cds,
     orf_matches_genbank_cds,
@@ -167,10 +169,63 @@ def test_orf_matches_genbank_cds_valid_c_terminal_matches(
 @pytest.mark.parametrize(
     ("orf_sequence", "cds_sequence"),
     [
-        ("MABCDEFGHIJK", "MABCDEFGHIJX"),
+        ("MABCDEFGHIJK", "MABXDEFGHIJK"),
+        ("MABXDEFGHIJK", "MABCDEFGHIJK"),
         ("MABCDEFGHIJK", "MABCXEFGHIJK"),
+        ("MABCDEFGHIJK", "MAXCDXFGHIXK"),
+    ],
+)
+def test_orf_matches_genbank_cds_accepts_aligned_x_residues(
+    orf_sequence: str,
+    cds_sequence: str,
+) -> None:
+    """An aligned X is compatible in either sequence, including repeatedly."""
+    assert orf_matches_genbank_cds(make_orf(orf_sequence), make_cds(cds_sequence))
+
+
+@pytest.mark.parametrize(
+    ("residue_a", "residue_b", "expected"),
+    [
+        ("A", "A", True),
+        ("X", "K", True),
+        ("K", "X", True),
+        ("X", "X", True),
+        ("B", "B", True),
+        ("B", "D", False),
+        ("Z", "Q", False),
+        ("J", "L", False),
+        ("U", "C", False),
+        ("O", "K", False),
+        ("*", "X", False),
+    ],
+)
+def test_amino_acids_are_compatible(
+    residue_a: str,
+    residue_b: str,
+    expected: bool,
+) -> None:
+    """Only X acts as a wildcard; other ambiguity symbols stay specific."""
+    assert amino_acids_are_compatible(residue_a, residue_b) is expected
+
+
+def test_compatible_c_terminal_suffix_remains_anchored() -> None:
+    """Compatibility does not enable internal, prefix, or indel matching."""
+    assert compatible_c_terminal_suffix("CDEFX", "ABCDEFK")
+    assert not compatible_c_terminal_suffix("ABCDE", "ABCDEXK")
+    assert not compatible_c_terminal_suffix("ABDE", "ABCDEFG")
+
+
+@pytest.mark.parametrize(
+    ("orf_sequence", "cds_sequence"),
+    [
+        ("MABCDEFGHIJK", "MABCDEFGHIJY"),
+        ("MABCDEFGHIJK", "MABCYEFGHIJK"),
         ("MABCDEFGHIJK", "XEFGHIJ"),
         ("MABCDEFGHIJK", "MABCDE"),
+        ("MABCDEFGHIJK", "MABCDEFGHIJ"),
+        ("MABCDEFGHIJK", "MABCDXEFGHIJK"),
+        ("MABCDEFGHIJK", "MABCXFGHIJK"),
+        ("MABC*DEFGHIJK", "MABCDEFGHIJK"),
     ],
 )
 def test_orf_matches_genbank_cds_rejects_non_terminal_matches(
@@ -220,6 +275,27 @@ def test_orf_matches_genbank_cds_uses_reverse_strand_low_coordinate() -> None:
         orf,
         make_cds("MABCDEFGHIJK", start=150, end=250, strand="-"),
     )
+
+
+def test_mf580763_ambiguous_residue_regression() -> None:
+    """MF580763 orf5 matches CDS 0014 despite its K/X ambiguity."""
+    shared_suffix = "MQIWIHDKSMRKVCALNNEIPGMLPYSNSQWHPYLEY"
+    orf_suffix = shared_suffix + "STFDFTIPKIVNGKLHDDLKYINDQMHVSFGGAKSVEWYLRN"
+    cds_suffix = shared_suffix + "STFDFTIPKIVNGKLHDDLKYINDQMHVSFGGAXSVEWYLRN"
+    orf5 = make_orf(
+        "NFLEGAFCL" + orf_suffix,
+        parent_id="MF580763",
+        start=14920,
+        end=18216,
+    )
+    cds_0014 = make_cds(
+        cds_suffix,
+        parent_id="MF580763",
+        start=14946,
+        end=18216,
+    )
+
+    assert orf_matches_genbank_cds(orf5, cds_0014)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -165,6 +165,41 @@ def test_protein_record_ambiguous_codons() -> None:
     assert protein.aa_length == 4
 
 
+@pytest.mark.parametrize(
+    ("codon", "expected_residue"),
+    [
+        ("AAN", "X"),
+        ("ATH", "I"),
+        ("GCN", "A"),
+        ("TTY", "F"),
+        ("NNN", "X"),
+    ],
+)
+def test_translate_orf_uses_iupac_ambiguity_semantics(
+    codon: str,
+    expected_residue: str,
+) -> None:
+    """Ambiguous codons resolve only when every expansion has one meaning."""
+    nucleotide_sequence = "ATG" + codon + "GGGTAA"
+    orf = OrfRecord(
+        parent_id="seq1",
+        orf_id=f"orf_{codon}",
+        start=1,
+        end=len(nucleotide_sequence),
+        strand="+",
+        frame=1,
+        nt_sequence=nucleotide_sequence,
+        aa_sequence="M" + expected_residue + "G*",
+        table_id=11,
+        has_start_codon=True,
+        has_stop_codon=True,
+    )
+
+    protein = translate_orf(orf, table_id=11)
+
+    assert protein.aa_sequence == "M" + expected_residue + "G"
+
+
 def test_translate_orf_warns_and_uses_translation_on_mismatch(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes false-negative GenBank CDS matching when one protein translation contains
an ambiguous `X` residue.

The matcher continues to require:

- the same parent sequence;
- the same strand;
- the same biological stop coordinate;
- a C-terminal suffix alignment.

Within the aligned suffix, `X` is now compatible with any valid amino-acid
symbol. All other unequal residues remain mismatches. `B`, `Z`, and `J` retain
their specific symbols rather than becoming wildcards; `U` and `O` are also
specific, and internal `*` symbols are rejected.

## Regression case

In genome `MF580763`, `orf5` and `MF580763_CDS_0014`:

- terminate at coordinate 18216 on the forward strand;
- have a C-terminal suffix relationship despite different starts;
- differ at aligned residue 115, where the ORF-derived translation contains
  `K`, the GenBank translation contains `X`, and the nucleotide codon is `AAN`.

The corrected matcher marks `orf5` as `in_genbank: true`. Applying the matcher
to the supplied 53 ORFs and 38 CDS features changes the match count from 31 to
32: `orf5` is the only new match, and no existing match is lost.

## Additional audit

- `pygenetic-code 0.20` translated `AAN` and `NNN` as lysine and `TTY` as
  leucine in the tested environment. `genome_entropy` now routes only
  ambiguity-containing DNA through Biopython's IUPAC-aware translator;
  unambiguous DNA still uses `pygenetic-code`. Tests cover `AAN -> X`,
  `ATH -> I`, `GCN -> A`, `TTY -> F`, and `NNN -> X`.
- Forward and reverse stop conversion remains unchanged and is covered by real
  parsed fixtures: forward uses the ORF/CDS ends, while reverse compares the
  one-based ORF start with the zero-based Biopython start plus one.
- The same-parent/same-strand/same-stop diagnostic found no other false
  negatives in MF580763. It identified only `orf5` as an unmatched candidate
  before the fix.
- The supplied MF580763 CDS features all have translations and simple
  locations. The documentation now records that missing `/translation` values
  cannot match and that origin-spanning compound locations, partial markers,
  `codon_start`, translation exceptions, pseudogenes, and frameshifts are not
  reinterpreted by the matcher.
- The requested synthetic spelling `MABCXFGHIJK` is one residue shorter than
  `MABCDEFGHIJK`; accepting it would make `X` consume two residues and violate
  the no-indel rule. The tests use `MABCXEFGHIJK` for the intended one-position
  substitution and explicitly reject `MABCXFGHIJK` as an indel.
- Translation mismatch warnings no longer print complete DNA and protein
  sequences; they report lengths and the first mismatch position.

## Validation

- focused GenBank and translation tests: 60 passed;
- full test suite: 243 passed, 9 skipped (model-download and optional-runtime
  integration tests were not enabled);
- formatter: Black passed for every changed Python file; literal
  `black --check .` was also attempted but stalled while traversing the large
  untracked validation tree;
- linter: Ruff passed for every changed Python file; repository-wide Ruff still
  reports 28 pre-existing findings in unrelated source, tests, and untracked
  utilities;
- type checker: mypy was attempted but is blocked by pre-existing missing stubs
  for `accelerate`, `sklearn`, and `PyGeneticCode`, plus NumPy stubs using syntax
  newer than the configured Python 3.10 target;
- Sphinx warnings-as-errors build: passed;
- MF580763 regression: `orf5 in_genbank = true`, 31 -> 32 total matches, only
  `orf5` added.

The supplied GenBank, JSON, stdout, and stderr files remain untracked and are
not included in this pull request.
