### PR TITLE
Fix failing Read the Docs PDF and EPUB builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,21 +34,25 @@ jobs:
           pip install -e .
           pip install -e ".[docs]"
 
-      - name: Build documentation
+      - name: Build documentation with warnings as errors
         run: |
-          python -m sphinx -W --keep-going -b html docs/source docs/build/html
+          python -m sphinx -T -W --keep-going -b html -d docs/_build/doctrees-html docs/source docs/_build/html
+          python -m sphinx -T -W --keep-going -b epub -d docs/_build/doctrees-epub docs/source docs/_build/epub
+          python -m sphinx -T -W --keep-going -b latex -d docs/_build/doctrees-latex docs/source docs/_build/latex
 
       - name: Check documentation build
         run: |
-          ls -la docs/build/html/
-          test -f docs/build/html/index.html
+          ls -la docs/_build/html/
+          test -f docs/_build/html/index.html
+          test -f docs/_build/html/.nojekyll
+          test ! -e docs/_build/epub/.nojekyll
 
       # Optional: keep a build artifact for debugging / downloads from Actions UI
       - name: Upload documentation artifacts
         uses: actions/upload-artifact@v6
         with:
           name: documentation
-          path: docs/build/html/
+          path: docs/_build/html/
           retention-days: 30
 
       # Upload the Pages artifact (used by actions/deploy-pages)
@@ -60,7 +64,7 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/build/html
+          path: docs/_build/html
 
   deploy-pages:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/docs/source/.nojekyll
+++ b/docs/source/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll processing for GitHub Pages HTML output.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,7 +2,9 @@
 
 import os
 import sys
-from importlib.metadata import PackageNotFoundError, version as package_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+from typing import Any
 
 # Add source directory to path for autodoc
 sys.path.insert(0, os.path.abspath("../../src"))
@@ -27,7 +29,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.githubpages",
     "myst_parser",
 ]
 
@@ -85,7 +86,7 @@ master_doc = "index"
 language = "en"
 
 # List of patterns to exclude
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 # HTML output options
 html_theme = "sphinx_rtd_theme"
@@ -106,7 +107,7 @@ intersphinx_mapping = {
 }
 
 # Add any paths that contain custom static files (such as style sheets)
-html_css_files = []
+html_css_files: list[str] = []
 
 # Output file base name for HTML help builder
 htmlhelp_basename = "genome_entropydoc"
@@ -119,3 +120,21 @@ html_context = {
     "github_version": "main",
     "conf_py_path": "/docs/source/",
 }
+
+
+def configure_builder_specific_files(app: Any) -> None:
+    """Include GitHub Pages files only in browser-oriented HTML builds."""
+    # EPUB also has ``format == "html"``, so select concrete HTML builders.
+    if app.builder.name in {"html", "dirhtml", "singlehtml"}:
+        app.config.html_extra_path = [".nojekyll"]
+    else:
+        app.config.html_extra_path = []
+
+
+def setup(app: Any) -> dict[str, object]:
+    """Configure builder-specific documentation files."""
+    app.connect("builder-inited", configure_builder_specific_files)
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -43,9 +43,9 @@ Shannon entropy
 
 For observed symbol frequencies ``p_i``, raw Shannon entropy in bits is:
 
-.. code-block:: text
+.. math::
 
-   H = -Σ p_i log₂(p_i)
+   H = -\sum_i p_i \log_2(p_i)
 
 Zero describes a sequence containing one observed symbol. Larger values reflect
 more even use of more symbols, but do not by themselves establish sequence

--- a/src/genome_entropy/entropy/shannon.py
+++ b/src/genome_entropy/entropy/shannon.py
@@ -85,8 +85,8 @@ def shannon_entropy(
 ) -> float:
     """Calculate Shannon entropy of a sequence.
 
-    Shannon entropy: H = -Σ(p_i × log₂(p_i))
-    where p_i is the frequency of symbol i.
+    Shannon entropy: :math:`H = -\\sum_i p_i \\log_2(p_i)`, where :math:`p_i` is
+    the frequency of symbol :math:`i`.
 
     Args:
         sequence: String to calculate entropy for
@@ -113,7 +113,7 @@ def shannon_entropy(
     counts = Counter(sequence)
     total = len(sequence)
 
-    # Calculate entropy: -Σ(p_i × log₂(p_i))
+    # Calculate entropy: -sum_i p_i * log2(p_i)
     entropy = 0.0
     for count in counts.values():
         if count > 0:


### PR DESCRIPTION
## Summary

Fixes the Read the Docs build failures by:

- replacing literal Unicode entropy formula symbols with proper Sphinx/LaTeX mathematical markup;
- restricting `.nojekyll` to browser-oriented HTML output so it is not packaged into EPUB;
- preserving warnings-as-errors and the configured PDF and EPUB formats;
- adding HTML, EPUB, and LaTeX documentation build regression checks.

## Root causes

### PDF

The PDF builder failed because pdfLaTeX could not render the literal Unicode
sigma character in entropy formulas.

### EPUB

The EPUB builder emitted `epub.unknown_project_files` because `.nojekyll` was
included as an EPUB project file. Read the Docs treats warnings as errors.

## Validation

- `pytest`: 243 passed, 9 skipped
- Sphinx HTML with `-W`: passed
- Sphinx EPUB with `-W`: passed
- Sphinx LaTeX with `-W`: passed
- PDF compilation: attempted; local TeX Live installation is missing `fncychap.sty`, before project content is processed. Read the Docs provides the complete TeX environment.
- `.nojekyll` assertions: passed for HTML presence and EPUB absence
- literal sigma search: no occurrences
- `.readthedocs.yaml` parse and configuration assertions: passed
- Ruff: passed for `conf.py` and focused error/import checks for the edited source module
- mypy: passed for both edited Python files
- Black: installed and invoked, but the check process did not return in the HPC execution wrapper

## Follow-up opportunity

The documentation extra still installs the full runtime stack, including PyTorch,
CUDA libraries, and XGBoost. Slimming that dependency path is intentionally
deferred to avoid broad packaging changes in this focused build fix.
