### PR TITLE
Add fast GenBank LOCUS extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ genome_entropy encode3di --input proteins.faa --output structures.json
 
 Run `genome_entropy --help` and `genome_entropy COMMAND --help` for the installed version's authoritative option list. Detailed examples are in the [quick-start guide](https://genome-entropy.readthedocs.io/en/latest/quickstart.html) and [CLI reference](https://genome-entropy.readthedocs.io/en/latest/cli.html).
 
+## Extract one GenBank record
+
+The dependency-free `bin/extract_genbank_locus` utility extracts one record
+from a large, uncompressed GenBank file. It matches the complete first token
+after `LOCUS`, writes from that `LOCUS` line through its terminating `//` line,
+and stops scanning immediately. Build it with a POSIX C compiler:
+
+```bash
+make -C bin
+bin/extract_genbank_locus INPUT.gbk LOCUS_ID OUTPUT.gbk
+```
+
+For example, `bin/extract_genbank_locus assemblies.gb NC_000913.3 ecoli.gb`
+matches `NC_000913.3` exactly; it will not match `NC_000913.30`. The output is
+created only after a complete matching record is found. Gzip input is not
+supported by this standalone utility; decompress it first.
+
 ## Supported encoders
 
 | Canonical model | Approximate size | 3Di | 12-state | Status |

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -1,0 +1,19 @@
+CC ?= cc
+CFLAGS ?= -O3 -DNDEBUG
+CPPFLAGS ?=
+LDFLAGS ?=
+
+TARGET := extract_genbank_locus
+
+.PHONY: all clean test
+
+all: $(TARGET)
+
+$(TARGET): extract_genbank_locus.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -Wpedantic $< $(LDFLAGS) -o $@
+
+test: $(TARGET)
+	../tests/test_extract_genbank_locus.sh ./$(TARGET)
+
+clean:
+	$(RM) $(TARGET)

--- a/bin/extract_genbank_locus.c
+++ b/bin/extract_genbank_locus.c
@@ -1,0 +1,198 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static void usage(const char *program)
+{
+    fprintf(stderr, "Usage: %s GENBANK_FILE LOCUS_ID OUTPUT_FILE\n", program);
+}
+
+static int write_all(int fd, const char *data, size_t length)
+{
+    while (length > 0) {
+        ssize_t written = write(fd, data, length);
+
+        if (written < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        data += (size_t)written;
+        length -= (size_t)written;
+    }
+    return 0;
+}
+
+static const char *line_end(const char *start, const char *end)
+{
+    const char *newline = memchr(start, '\n', (size_t)(end - start));
+    return newline == NULL ? end : newline;
+}
+
+static const char *next_line(const char *end_of_line, const char *end)
+{
+    return end_of_line < end ? end_of_line + 1 : end;
+}
+
+static size_t content_length(const char *start, const char *end_of_line)
+{
+    size_t length = (size_t)(end_of_line - start);
+    return length > 0 && start[length - 1] == '\r' ? length - 1 : length;
+}
+
+static int locus_matches(const char *start, const char *end_of_line,
+                         const char *wanted, size_t wanted_length)
+{
+    size_t length = content_length(start, end_of_line);
+    const char *cursor;
+    const char *limit = start + length;
+    const char *id_start;
+
+    if (length <= 5 || memcmp(start, "LOCUS", 5) != 0)
+        return 0;
+    cursor = start + 5;
+    if (*cursor != ' ' && *cursor != '\t')
+        return 0;
+    while (cursor < limit && (*cursor == ' ' || *cursor == '\t'))
+        ++cursor;
+    id_start = cursor;
+    while (cursor < limit && *cursor != ' ' && *cursor != '\t')
+        ++cursor;
+
+    return (size_t)(cursor - id_start) == wanted_length &&
+           memcmp(id_start, wanted, wanted_length) == 0;
+}
+
+static const char *record_end(const char *start, const char *end)
+{
+    const char *cursor = start;
+
+    while (cursor < end) {
+        const char *end_of_line = line_end(cursor, end);
+        size_t length = content_length(cursor, end_of_line);
+
+        if (length == 2 && cursor[0] == '/' && cursor[1] == '/')
+            return next_line(end_of_line, end);
+        cursor = next_line(end_of_line, end);
+    }
+    return NULL;
+}
+
+int main(int argc, char **argv)
+{
+    int input_fd = -1;
+    int output_fd = -1;
+    struct stat input_stat;
+    struct stat output_stat;
+    const char *mapping = MAP_FAILED;
+    const char *end;
+    const char *cursor;
+    const char *match = NULL;
+    const char *match_end = NULL;
+    size_t locus_length;
+    int result = EXIT_FAILURE;
+
+    if (argc != 4) {
+        usage(argv[0]);
+        return 2;
+    }
+    locus_length = strlen(argv[2]);
+    if (locus_length == 0 || strpbrk(argv[2], " \t\r\n") != NULL) {
+        fprintf(stderr, "LOCUS_ID must be one non-empty, whitespace-free token\n");
+        return 2;
+    }
+
+    input_fd = open(argv[1], O_RDONLY);
+    if (input_fd < 0) {
+        fprintf(stderr, "Cannot open input '%s': %s\n", argv[1], strerror(errno));
+        goto cleanup;
+    }
+    if (fstat(input_fd, &input_stat) < 0) {
+        fprintf(stderr, "Cannot inspect input '%s': %s\n", argv[1], strerror(errno));
+        goto cleanup;
+    }
+    if (!S_ISREG(input_stat.st_mode)) {
+        fprintf(stderr, "Input '%s' is not a regular file\n", argv[1]);
+        goto cleanup;
+    }
+    if (input_stat.st_size == 0) {
+        fprintf(stderr, "LOCUS '%s' was not found in '%s'\n", argv[2], argv[1]);
+        result = 3;
+        goto cleanup;
+    }
+
+    mapping = mmap(NULL, (size_t)input_stat.st_size, PROT_READ, MAP_PRIVATE,
+                   input_fd, 0);
+    if (mapping == MAP_FAILED) {
+        fprintf(stderr, "Cannot map input '%s': %s\n", argv[1], strerror(errno));
+        goto cleanup;
+    }
+#ifdef POSIX_MADV_SEQUENTIAL
+    (void)posix_madvise((void *)mapping, (size_t)input_stat.st_size,
+                        POSIX_MADV_SEQUENTIAL);
+#endif
+
+    end = mapping + input_stat.st_size;
+    cursor = mapping;
+    while (cursor < end) {
+        const char *end_of_line = line_end(cursor, end);
+
+        if (locus_matches(cursor, end_of_line, argv[2], locus_length)) {
+            match = cursor;
+            match_end = record_end(next_line(end_of_line, end), end);
+            break;
+        }
+        cursor = next_line(end_of_line, end);
+    }
+
+    if (match == NULL) {
+        fprintf(stderr, "LOCUS '%s' was not found in '%s'\n", argv[2], argv[1]);
+        result = 3;
+        goto cleanup;
+    }
+    if (match_end == NULL) {
+        fprintf(stderr, "LOCUS '%s' has no terminating // line\n", argv[2]);
+        result = 4;
+        goto cleanup;
+    }
+
+    output_fd = open(argv[3], O_WRONLY | O_CREAT, 0666);
+    if (output_fd < 0) {
+        fprintf(stderr, "Cannot open output '%s': %s\n", argv[3], strerror(errno));
+        goto cleanup;
+    }
+    if (fstat(output_fd, &output_stat) < 0) {
+        fprintf(stderr, "Cannot inspect output '%s': %s\n", argv[3], strerror(errno));
+        goto cleanup;
+    }
+    if (input_stat.st_dev == output_stat.st_dev &&
+        input_stat.st_ino == output_stat.st_ino) {
+        fprintf(stderr, "Input and output must be different files\n");
+        goto cleanup;
+    }
+    if (ftruncate(output_fd, 0) < 0 ||
+        write_all(output_fd, match, (size_t)(match_end - match)) < 0) {
+        fprintf(stderr, "Cannot write output '%s': %s\n", argv[3], strerror(errno));
+        goto cleanup;
+    }
+
+    result = EXIT_SUCCESS;
+
+cleanup:
+    if (output_fd >= 0 && close(output_fd) < 0 && result == EXIT_SUCCESS) {
+        fprintf(stderr, "Cannot close output '%s': %s\n", argv[3], strerror(errno));
+        result = EXIT_FAILURE;
+    }
+    if (mapping != MAP_FAILED)
+        (void)munmap((void *)mapping, (size_t)input_stat.st_size);
+    if (input_fd >= 0)
+        (void)close(input_fd);
+    return result;
+}

--- a/tests/test_extract_genbank_locus.sh
+++ b/tests/test_extract_genbank_locus.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -eu
+
+program=${1:-bin/extract_genbank_locus}
+case "$program" in
+    /*) ;;
+    *) program="$(pwd)/$program" ;;
+esac
+
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/extract-genbank-locus.XXXXXX")
+trap 'rm -rf "$test_dir"' EXIT HUP INT TERM
+cd "$test_dir"
+
+printf '%s\n' \
+    'LOCUS       PREFIX             10 bp    DNA' \
+    'DEFINITION  prefix record.' \
+    'ORIGIN' \
+    '        1 aaaaaaaaaa' \
+    '//' \
+    'LOCUS       PREFIX_LONG        12 bp    DNA' \
+    'DEFINITION  exact record.' \
+    'ORIGIN' \
+    '        1 cccccccccccc' \
+    '//' \
+    'LOCUS       AFTER              8 bp    DNA' \
+    'DEFINITION  must not be copied.' \
+    '//' > records.gb
+
+"$program" records.gb PREFIX_LONG extracted.gb
+printf '%s\n' \
+    'LOCUS       PREFIX_LONG        12 bp    DNA' \
+    'DEFINITION  exact record.' \
+    'ORIGIN' \
+    '        1 cccccccccccc' \
+    '//' > expected.gb
+cmp expected.gb extracted.gb
+
+if "$program" records.gb MISSING missing.gb 2>/dev/null; then
+    echo "missing LOCUS unexpectedly succeeded" >&2
+    exit 1
+fi
+test ! -e missing.gb
+
+printf 'LOCUS       CRLF_ID       4 bp    DNA\r\nORIGIN\r\n        1 acgt\r\n//\r\ntrailing data\r\n' > crlf.gb
+"$program" crlf.gb CRLF_ID crlf-output.gb
+printf 'LOCUS       CRLF_ID       4 bp    DNA\r\nORIGIN\r\n        1 acgt\r\n//\r\n' > crlf-expected.gb
+cmp crlf-expected.gb crlf-output.gb
+
+cp records.gb same.gb
+if "$program" same.gb PREFIX same.gb 2>/dev/null; then
+    echo "same input and output unexpectedly succeeded" >&2
+    exit 1
+fi
+cmp records.gb same.gb
+
+printf '%s\n' 'extract_genbank_locus tests passed'


### PR DESCRIPTION
## Summary

- add a dependency-free POSIX C utility that memory-maps large GenBank files
- match the exact LOCUS identifier token and write only the selected record
- stop scanning at the selected record's terminating `//` line
- add build instructions, usage documentation, and regression tests

## User impact

Users can extract one record from a large, uncompressed multi-record GenBank file without loading or parsing the whole file through a third-party library. Output is not created unless a complete matching record is found, and input/output aliasing is rejected to protect source data.

## Validation

- `make -C bin clean all test`
- AddressSanitizer and UndefinedBehaviorSanitizer build/test with `ASAN_OPTIONS=detect_leaks=0` (LeakSanitizer is unavailable under the sandbox tracer)
- `git diff --check`