### PR TITLE
Fix false-negative GenBank CDS matching

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,15 @@ Changelog
 Unreleased
 ----------
 
+Fixes
+^^^^^
+
+* Replaced stop-coordinate/C-terminal CDS matching with coordinate-normalised,
+  strand- and phase-aware genomic overlap plus aligned translation comparison.
+  Alternative starts, ambiguous ``X`` residues, small terminal differences,
+  CDS-specific translation tables, ``codon_start``, and missing translation
+  qualifiers are now handled without unrestricted local matching.
+
 Documentation
 ^^^^^^^^^^^^^
 

--- a/docs/source/data_formats.rst
+++ b/docs/source/data_formats.rst
@@ -81,30 +81,44 @@ GenBank matching and ``in_genbank``
 -----------------------------------
 
 When GenBank annotations are supplied, CDS features are extracted with Biopython
-and compared to called ORFs on the same parent sequence and strand. The current
-matcher:
+and compared to called ORFs. Public ORF coordinates remain one-based and
+inclusive. Matching converts positive-strand ORFs and the reverse-complement
+coordinates reported for negative-strand ORFs to a single zero-based,
+half-open genomic convention. Biopython locations already use that internal
+convention. ``codon_start`` offsets are applied at the biological CDS start.
 
-* requires equal strand-aware biological stop coordinates (``end`` on ``+`` and
-  ``start`` on ``-`` after converting Biopython coordinates);
-* strips terminal ``*`` symbols from both translations;
-* ignores the first amino acid before sequence comparison, accommodating start
-  codon differences;
-* accepts compatible C-terminal suffixes and truncated C-terminal subset
-  matches;
-* treats ``X`` as an unknown residue compatible with any aligned amino-acid
-  symbol, while all other unequal pairs remain mismatches. ``B``, ``Z``, and
-  ``J`` are not treated as wildcards, and internal ``*`` symbols are invalid.
+A match requires the same parent record, strand, and codon phase. The genomic
+intersection must cover at least 90% of the shorter coding interval. Amino-acid
+slices are then selected from the shared genomic codons; at least 98% of those
+aligned residues must be compatible. This recognises alternative start codons,
+N-terminal extensions, contained gene models, and small terminal differences
+without accepting an arbitrary conserved domain or unrestricted local protein
+similarity.
 
-``in_genbank=True`` therefore means this heuristic matched an annotated CDS. It
-does not require exact full-length identity and does not establish biological
-function. Missing GenBank annotation input leaves the field false.
+Whitespace and case are ignored in translations, as is one terminal ``*``.
+``X`` in either aligned translation is an unknown residue compatible with any
+valid amino-acid symbol. Other unequal pairs, internal stops, internal
+insertions, and internal deletions remain mismatches.
 
-CDS matching uses the supplied ``/translation`` qualifier. CDS features without
-that qualifier cannot currently match. Compound and origin-spanning locations
-are parsed by Biopython, but origin-spanning biological stop coordinates are not
-yet handled specially. Partial markers, ``codon_start``, translation exceptions,
-pseudogenes, and frameshifts are not reinterpreted by the matcher; their effect
-must already be represented in the supplied translation and location.
+The annotation's ``/translation`` is preferred. If it is absent, the CDS
+nucleotides are extracted in biological orientation, adjusted by
+``codon_start``, and translated with the CDS ``transl_table``. The fallback
+order is an explicit record/source translation table, the pipeline table, then
+the project default. A CDS table therefore need not equal the ORF caller's
+global table.
+
+Simple partial CDS locations can match when their represented interval and
+translation satisfy the same thresholds. Joined, compound, and
+origin-crossing locations cannot be mapped safely to the current contiguous
+ORF representation and are skipped with a debug message rather than flattened.
+Translation exceptions, pseudogenes, and frameshifts are not independently
+reconstructed. Debug logging reports identifiers, normalised coordinates,
+phase, overlap, aligned length, wildcard count, identity, decision, and reason,
+but never full sequences.
+
+``in_genbank=True`` means this coordinate-anchored heuristic matched an
+annotated CDS; it does not establish biological function. Missing GenBank
+annotation input leaves the field false.
 
 .. _raw-and-normalised-entropy:
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -88,10 +88,12 @@ annotation match, not a functional assignment. ML predictions learn this label
 and inherit its biases. Use genome- or file-level splits to estimate transfer to
 unseen records and read :doc:`ml` before reporting results.
 
-The GenBank heuristic requires the same parent, strand, and biological stop,
-then compares C-terminal suffixes after ignoring each protein's first residue.
-An aligned ``X`` is compatible with a specific residue, but unrelated mismatches
-and internal or N-terminal-only similarity remain disallowed. For nucleotide
-translation, multiply-resolvable IUPAC codons such as ``AAN`` and ``NNN`` become
-``X``; ambiguities with one translation, such as ``GCN`` (alanine), retain that
-specific amino acid.
+The GenBank heuristic normalises ORF and Biopython coordinates, then requires
+the same parent, strand, codon phase, at least 90% overlap of the shorter coding
+interval, and at least 98% compatibility across coordinate-aligned amino acids.
+This permits alternative starts and small terminal differences but not
+arbitrary local protein similarity. An aligned ``X`` is compatible with a
+specific residue. CDS-specific ``transl_table`` and ``codon_start`` qualifiers
+are respected, including when a missing ``/translation`` must be generated from
+the feature nucleotides. See :doc:`data_formats` for compound-location and
+partial-CDS handling.

--- a/src/genome_entropy/cli/commands/run.py
+++ b/src/genome_entropy/cli/commands/run.py
@@ -71,7 +71,7 @@ def run_command(
         "-g",
         help="GenBank file with DNA sequences and CDS annotations. "
         "Can be used instead of --input to provide both sequences and annotations. "
-        "ORFs will be matched to GenBank CDS features by C-terminal sequence.",
+        "ORFs are matched to CDS features by genomic overlap, frame, and translation.",
         exists=True,
         dir_okay=False,
     ),

--- a/src/genome_entropy/io/genbank.py
+++ b/src/genome_entropy/io/genbank.py
@@ -3,16 +3,57 @@
 import gzip
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from Bio import SeqIO
+from Bio.Seq import Seq
+from Bio.SeqFeature import CompoundLocation, SeqFeature
+from Bio.SeqRecord import SeqRecord
 
+from ..config import DEFAULT_GENETIC_CODE_TABLE
 from ..logging_config import get_logger
 from ..orf.types import OrfRecord
 
 logger = get_logger(__name__)
 
 VALID_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWYBJZUOX")
+MIN_CDS_OVERLAP_FRACTION = 0.90
+MIN_SHARED_AA_IDENTITY = 0.98
+
+
+@dataclass(frozen=True)
+class CodingInterval:
+    """A coding interval in zero-based, half-open genomic coordinates."""
+
+    start: int
+    end: int
+    strand: Literal["+", "-"]
+
+    def __post_init__(self) -> None:
+        if self.start < 0 or self.end <= self.start:
+            raise ValueError(f"Invalid coding interval: [{self.start}, {self.end})")
+        if self.strand not in ("+", "-"):
+            raise ValueError(f"Invalid coding strand: {self.strand}")
+
+    @property
+    def length(self) -> int:
+        """Return the genomic interval length in nucleotides."""
+        return self.end - self.start
+
+
+@dataclass(frozen=True)
+class CdsMatchResult:
+    """Diagnostics from one coordinate-anchored ORF/CDS comparison."""
+
+    matched: bool
+    overlap_nt: int = 0
+    overlap_fraction: float = 0.0
+    compared_aa: int = 0
+    compatible_aa: int = 0
+    wildcard_aa: int = 0
+    identity: float = 0.0
+    phase_compatible: bool = False
+    reason: str = ""
 
 
 @dataclass
@@ -25,13 +66,26 @@ class GenBankCDS:
         end: 0-based end position (exclusive)
         strand: Strand orientation ('+' or '-')
         protein_sequence: Translated protein sequence
+        record_length: Length of the parent sequence, needed to convert
+            reverse-complement ORF coordinates to genomic coordinates
+        feature_id: Stable CDS identifier used in diagnostics
+        translation_table: NCBI genetic code used by this CDS
+        codon_start: One-based offset of the first complete CDS codon
+        partial: Whether either Biopython location boundary is partial
+        skip_reason: Why this feature cannot safely be matched, if applicable
     """
 
     parent_id: str
     start: int
     end: int
-    strand: str
+    strand: Literal["+", "-"]
     protein_sequence: str
+    record_length: Optional[int] = None
+    feature_id: str = ""
+    translation_table: int = DEFAULT_GENETIC_CODE_TABLE
+    codon_start: int = 1
+    partial: bool = False
+    skip_reason: str = ""
 
 
 def read_genbank(genbank_path: Union[str, Path]) -> Dict[str, str]:
@@ -86,7 +140,73 @@ def read_genbank(genbank_path: Union[str, Path]) -> Dict[str, str]:
     return sequences
 
 
-def extract_cds_features(genbank_path: Union[str, Path]) -> List[GenBankCDS]:
+def _first_qualifier(qualifiers: Dict[str, List[str]], name: str) -> Optional[str]:
+    """Return the first non-empty value for a GenBank qualifier."""
+    values = qualifiers.get(name, [])
+    return values[0] if values else None
+
+
+def _translation_table(
+    qualifiers: Dict[str, List[str]],
+    record_default: Optional[int],
+    pipeline_default: int,
+) -> int:
+    """Resolve the CDS genetic code with increasingly broad fallbacks."""
+    value = _first_qualifier(qualifiers, "transl_table")
+    if value is not None:
+        try:
+            return int(value)
+        except ValueError:
+            logger.debug("Ignoring invalid CDS transl_table=%r", value)
+    return record_default or pipeline_default or DEFAULT_GENETIC_CODE_TABLE
+
+
+def _record_translation_table(record: SeqRecord) -> Optional[int]:
+    """Read a record-level translation table when one is explicitly present."""
+    annotations = getattr(record, "annotations", {})
+    value = annotations.get("transl_table")
+    if value is not None:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            logger.debug("Ignoring invalid record transl_table=%r", value)
+
+    for feature in getattr(record, "features", []):
+        if feature.type != "source":
+            continue
+        source_value = _first_qualifier(feature.qualifiers, "transl_table")
+        if source_value is not None:
+            try:
+                return int(source_value)
+            except ValueError:
+                logger.debug("Ignoring invalid source transl_table=%r", source_value)
+    return None
+
+
+def _fallback_feature_translation(
+    feature: SeqFeature,
+    record_sequence: Seq,
+    codon_start: int,
+    translation_table: int,
+) -> str:
+    """Translate one CDS feature when its annotation omits ``/translation``."""
+    coding_sequence = feature.extract(record_sequence)
+    coding_sequence = coding_sequence[codon_start - 1 :]
+    complete_length = len(coding_sequence) - (len(coding_sequence) % 3)
+    if complete_length == 0:
+        return ""
+    return str(
+        coding_sequence[:complete_length].translate(
+            table=translation_table,
+            to_stop=False,
+        )
+    )
+
+
+def extract_cds_features(
+    genbank_path: Union[str, Path],
+    pipeline_table_id: int = DEFAULT_GENETIC_CODE_TABLE,
+) -> List[GenBankCDS]:
     """Extract CDS features from a GenBank file.
 
     Automatically detects and handles gzipped files (ending in .gz).
@@ -119,22 +239,79 @@ def extract_cds_features(genbank_path: Union[str, Path]) -> List[GenBankCDS]:
         with open_func(genbank_path, mode) as handle:
             for record in SeqIO.parse(handle, "genbank"):
                 seq_id = record.id
+                record_length = len(record)
+                record_table = _record_translation_table(record)
 
                 for feature in record.features:
                     if feature.type != "CDS":
                         continue
 
-                    # Get protein translation if available
-                    protein_seq = ""
-                    if "translation" in feature.qualifiers:
-                        protein_seq = feature.qualifiers["translation"][0]
+                    qualifiers = feature.qualifiers
+                    feature_id = (
+                        _first_qualifier(qualifiers, "protein_id")
+                        or _first_qualifier(qualifiers, "locus_tag")
+                        or _first_qualifier(qualifiers, "gene")
+                        or f"{seq_id}:{feature.location}"
+                    )
+                    try:
+                        codon_start = int(
+                            _first_qualifier(qualifiers, "codon_start") or "1"
+                        )
+                    except ValueError:
+                        codon_start = 1
+                    if codon_start not in (1, 2, 3):
+                        logger.debug(
+                            "Skipping CDS %s: invalid codon_start=%r",
+                            feature_id,
+                            _first_qualifier(qualifiers, "codon_start"),
+                        )
+                        continue
+                    translation_table = _translation_table(
+                        qualifiers,
+                        record_table,
+                        pipeline_table_id,
+                    )
 
-                    # Convert strand
-                    strand = "+" if feature.location.strand == 1 else "-"
+                    if isinstance(feature.location, CompoundLocation):
+                        logger.debug(
+                            "Skipping CDS %s: compound or origin-crossing location %s "
+                            "cannot be mapped to one contiguous ORF",
+                            feature_id,
+                            feature.location,
+                        )
+                        continue
+                    if feature.location.strand not in (1, -1):
+                        logger.debug(
+                            "Skipping CDS %s: location has no definite strand",
+                            feature_id,
+                        )
+                        continue
 
-                    # BioPython uses 0-based coordinates (inclusive start, exclusive end)
+                    strand: Literal["+", "-"] = (
+                        "+" if feature.location.strand == 1 else "-"
+                    )
                     start = int(feature.location.start)
                     end = int(feature.location.end)
+                    offset = codon_start - 1
+                    if strand == "+":
+                        start += offset
+                    else:
+                        end -= offset
+                    if end <= start:
+                        logger.debug(
+                            "Skipping CDS %s: codon_start leaves an empty interval",
+                            feature_id,
+                        )
+                        continue
+
+                    protein_seq = _first_qualifier(qualifiers, "translation")
+                    if protein_seq is None:
+                        protein_seq = _fallback_feature_translation(
+                            feature,
+                            record.seq,
+                            codon_start,
+                            translation_table,
+                        )
 
                     cds = GenBankCDS(
                         parent_id=seq_id,
@@ -142,15 +319,29 @@ def extract_cds_features(genbank_path: Union[str, Path]) -> List[GenBankCDS]:
                         end=end,
                         strand=strand,
                         protein_sequence=protein_seq,
+                        record_length=record_length,
+                        feature_id=feature_id,
+                        translation_table=translation_table,
+                        codon_start=codon_start,
+                        partial=(
+                            feature.location.start.__class__.__name__ != "ExactPosition"
+                            or feature.location.end.__class__.__name__
+                            != "ExactPosition"
+                        ),
                     )
                     cds_features.append(cds)
                     logger.debug(
-                        "Extracted CDS: %s %s:%d-%d (protein_len=%d)",
+                        "Extracted CDS %s: %s %s:%d-%d "
+                        "(protein_len=%d, table=%d, codon_start=%d, partial=%s)",
+                        feature_id,
                         seq_id,
                         strand,
                         start,
                         end,
                         len(protein_seq),
+                        translation_table,
+                        codon_start,
+                        cds.partial,
                     )
     except Exception as e:
         logger.error("Failed to extract CDS features: %s", e)
@@ -183,66 +374,238 @@ def amino_acids_are_compatible(residue_a: str, residue_b: str) -> bool:
     return residue_a == residue_b or residue_a == "X" or residue_b == "X"
 
 
-def compatible_c_terminal_suffix(shorter: str, longer: str) -> bool:
-    """Return whether ``shorter`` compatibly aligns to the end of ``longer``."""
-    if not shorter or len(shorter) > len(longer):
-        return False
+def normalise_orf_coordinates(
+    orf: OrfRecord,
+    record_length: Optional[int],
+) -> CodingInterval:
+    """Convert get_orfs one-based inclusive coordinates to genomic coordinates.
 
-    longer_tail = longer[-len(shorter) :]
-    return all(
-        amino_acids_are_compatible(shorter_residue, longer_residue)
-        for shorter_residue, longer_residue in zip(shorter, longer_tail)
+    Positive-strand coordinates index the source sequence. Negative-strand
+    coordinates index its reverse complement and therefore require the parent
+    record length to map them back to the genomic axis.
+    """
+    if orf.start < 1 or orf.end < orf.start:
+        raise ValueError(f"Invalid ORF coordinates: start={orf.start}, end={orf.end}")
+    if orf.strand == "+":
+        return CodingInterval(orf.start - 1, orf.end, "+")
+    if record_length is None:
+        raise ValueError("record length is required for a reverse-strand ORF")
+    if orf.end > record_length:
+        raise ValueError(f"ORF end {orf.end} exceeds record length {record_length}")
+    return CodingInterval(record_length - orf.end, record_length - orf.start + 1, "-")
+
+
+def normalise_genbank_coordinates(cds: GenBankCDS) -> CodingInterval:
+    """Return a CDS's already-normalised Biopython genomic interval."""
+    return CodingInterval(cds.start, cds.end, cds.strand)
+
+
+def coding_phase_is_compatible(
+    orf_interval: CodingInterval,
+    cds_interval: CodingInterval,
+) -> bool:
+    """Return whether biological translation starts share a codon phase."""
+    if orf_interval.strand != cds_interval.strand:
+        return False
+    if orf_interval.strand == "+":
+        difference = orf_interval.start - cds_interval.start
+    else:
+        difference = orf_interval.end - cds_interval.end
+    return difference % 3 == 0
+
+
+def calculate_interval_overlap(
+    first: CodingInterval,
+    second: CodingInterval,
+) -> tuple[int, float]:
+    """Return overlap length and its fraction of the shorter interval."""
+    overlap = max(0, min(first.end, second.end) - max(first.start, second.start))
+    fraction = overlap / min(first.length, second.length)
+    return overlap, fraction
+
+
+def _shared_protein_slices(
+    orf_interval: CodingInterval,
+    cds_interval: CodingInterval,
+) -> tuple[int, int, int]:
+    """Map the shared genomic codons to ORF/CDS protein offsets and a length."""
+    overlap_start = max(orf_interval.start, cds_interval.start)
+    overlap_end = min(orf_interval.end, cds_interval.end)
+    if overlap_end <= overlap_start:
+        return 0, 0, 0
+
+    if orf_interval.strand == "+":
+        shared_start = overlap_start
+        shared_codons = (overlap_end - shared_start) // 3
+        return (
+            (shared_start - orf_interval.start) // 3,
+            (shared_start - cds_interval.start) // 3,
+            shared_codons,
+        )
+
+    shared_end = overlap_end
+    shared_codons = (shared_end - overlap_start) // 3
+    return (
+        (orf_interval.end - shared_end) // 3,
+        (cds_interval.end - shared_end) // 3,
+        shared_codons,
+    )
+
+
+def compare_shared_translation(
+    orf_sequence: str,
+    cds_sequence: str,
+    orf_offset: int,
+    cds_offset: int,
+    shared_codons: int,
+) -> CdsMatchResult:
+    """Compare coordinate-aligned amino acids without gaps or local alignment."""
+    orf_protein = normalise_protein_sequence(orf_sequence)
+    cds_protein = normalise_protein_sequence(cds_sequence)
+    available = min(
+        shared_codons,
+        max(0, len(orf_protein) - orf_offset),
+        max(0, len(cds_protein) - cds_offset),
+    )
+    minimum_coverage = max(1, shared_codons - 1)
+    if available < minimum_coverage:
+        return CdsMatchResult(
+            False,
+            compared_aa=available,
+            reason=(
+                "translations do not cover all shared codons except a possible "
+                "terminal stop"
+            ),
+        )
+
+    compatible = 0
+    wildcards = 0
+    for orf_residue, cds_residue in zip(
+        orf_protein[orf_offset : orf_offset + available],
+        cds_protein[cds_offset : cds_offset + available],
+    ):
+        if amino_acids_are_compatible(orf_residue, cds_residue):
+            compatible += 1
+            if orf_residue == "X" or cds_residue == "X":
+                wildcards += 1
+    identity = compatible / available
+    return CdsMatchResult(
+        identity >= MIN_SHARED_AA_IDENTITY,
+        compared_aa=available,
+        compatible_aa=compatible,
+        wildcard_aa=wildcards,
+        identity=identity,
+        reason=(
+            "shared translation identity passed"
+            if identity >= MIN_SHARED_AA_IDENTITY
+            else "shared translation identity below threshold"
+        ),
+    )
+
+
+def evaluate_orf_genbank_cds_match(
+    orf: OrfRecord,
+    cds: GenBankCDS,
+) -> CdsMatchResult:
+    """Evaluate one genomic, strand, phase, overlap, and translation match."""
+    if orf.parent_id != cds.parent_id:
+        return CdsMatchResult(False, reason="different parent sequence")
+    if orf.strand != cds.strand:
+        return CdsMatchResult(False, reason="different strand")
+    if cds.skip_reason:
+        return CdsMatchResult(False, reason=cds.skip_reason)
+
+    try:
+        orf_interval = normalise_orf_coordinates(orf, cds.record_length)
+        cds_interval = normalise_genbank_coordinates(cds)
+    except ValueError as error:
+        return CdsMatchResult(False, reason=str(error))
+
+    phase_compatible = coding_phase_is_compatible(orf_interval, cds_interval)
+    overlap_nt, overlap_fraction = calculate_interval_overlap(
+        orf_interval,
+        cds_interval,
+    )
+    if not phase_compatible:
+        return CdsMatchResult(
+            False,
+            overlap_nt=overlap_nt,
+            overlap_fraction=overlap_fraction,
+            reason="different codon phase",
+        )
+    if overlap_fraction < MIN_CDS_OVERLAP_FRACTION:
+        return CdsMatchResult(
+            False,
+            overlap_nt=overlap_nt,
+            overlap_fraction=overlap_fraction,
+            phase_compatible=True,
+            reason="genomic overlap below threshold",
+        )
+
+    orf_offset, cds_offset, shared_codons = _shared_protein_slices(
+        orf_interval,
+        cds_interval,
+    )
+    translation_result = compare_shared_translation(
+        orf.aa_sequence,
+        cds.protein_sequence,
+        orf_offset,
+        cds_offset,
+        shared_codons,
+    )
+    return CdsMatchResult(
+        translation_result.matched,
+        overlap_nt=overlap_nt,
+        overlap_fraction=overlap_fraction,
+        compared_aa=translation_result.compared_aa,
+        compatible_aa=translation_result.compatible_aa,
+        wildcard_aa=translation_result.wildcard_aa,
+        identity=translation_result.identity,
+        phase_compatible=True,
+        reason=translation_result.reason,
+    )
+
+
+def _log_match_result(
+    orf: OrfRecord,
+    cds: GenBankCDS,
+    result: CdsMatchResult,
+) -> None:
+    """Emit structured debug diagnostics without logging sequence content."""
+    try:
+        orf_interval = normalise_orf_coordinates(orf, cds.record_length)
+        cds_interval = normalise_genbank_coordinates(cds)
+        coordinates = (
+            f"orf=[{orf_interval.start},{orf_interval.end}) "
+            f"cds=[{cds_interval.start},{cds_interval.end})"
+        )
+    except ValueError:
+        coordinates = "coordinates=invalid"
+    logger.debug(
+        "GenBank CDS match orf_id=%s cds_id=%s strand=%s %s phase=%s "
+        "overlap_nt=%d overlap_fraction=%.4f compared_aa=%d wildcard_aa=%d "
+        "identity=%.4f matched=%s reason=%s",
+        orf.orf_id,
+        cds.feature_id or "<unknown>",
+        orf.strand,
+        coordinates,
+        result.phase_compatible,
+        result.overlap_nt,
+        result.overlap_fraction,
+        result.compared_aa,
+        result.wildcard_aa,
+        result.identity,
+        result.matched,
+        result.reason,
     )
 
 
 def orf_matches_genbank_cds(orf: OrfRecord, cds: GenBankCDS) -> bool:
-    """Match proteins by strand-aware stop and compatible C-terminal sequence.
-
-    C-terminal matching recognises partial CDS translations and alternative
-    initiation residues. ``X`` is compatible with any valid amino-acid symbol
-    at an aligned position; all other unequal residues remain mismatches.
-    """
-    if orf.parent_id != cds.parent_id or orf.strand != cds.strand:
-        return False
-
-    # get_orfs reports one-based inclusive coordinates. Biopython reports
-    # zero-based, half-open locations, so only the reverse-strand low coordinate
-    # needs an offset when comparing biological translation termination sites.
-    orf_stop = orf.end if orf.strand == "+" else orf.start
-    cds_stop = cds.end if cds.strand == "+" else cds.start + 1
-    if orf_stop != cds_stop:
-        return False
-
-    orf_c_terminal = normalise_protein_sequence(orf.aa_sequence)[1:]
-    cds_c_terminal = normalise_protein_sequence(cds.protein_sequence)[1:]
-    if not orf_c_terminal or not cds_c_terminal:
-        return False
-
-    shorter, longer = sorted(
-        (orf_c_terminal, cds_c_terminal),
-        key=len,
-    )
-    matches = compatible_c_terminal_suffix(shorter, longer)
-    if not matches and len(shorter) <= len(longer):
-        longer_tail = longer[-len(shorter) :]
-        for position, (shorter_residue, longer_residue) in enumerate(
-            zip(shorter, longer_tail),
-            start=1,
-        ):
-            if not amino_acids_are_compatible(shorter_residue, longer_residue):
-                logger.debug(
-                    "ORF %s and CDS at %s:%d-%d share a stop coordinate but "
-                    "differ at aligned residue %d: %s versus %s",
-                    orf.orf_id,
-                    cds.parent_id,
-                    cds.start,
-                    cds.end,
-                    position,
-                    shorter_residue,
-                    longer_residue,
-                )
-                break
-    return matches
+    """Return whether an ORF and CDS represent the same coordinate-anchored gene."""
+    result = evaluate_orf_genbank_cds_match(orf, cds)
+    if orf.parent_id == cds.parent_id and orf.strand == cds.strand:
+        _log_match_result(orf, cds, result)
+    return result.matched
 
 
 def match_orf_to_genbank_cds(
@@ -253,8 +616,9 @@ def match_orf_to_genbank_cds(
     for cds in genbank_cds_list:
         if orf_matches_genbank_cds(orf, cds):
             logger.debug(
-                "ORF %s matches GenBank CDS at %s:%d-%d (%s)",
+                "ORF %s matches GenBank CDS %s at %s:%d-%d (%s)",
                 orf.orf_id,
+                cds.feature_id or "<unknown>",
                 cds.parent_id,
                 cds.start,
                 cds.end,

--- a/src/genome_entropy/orf/types.py
+++ b/src/genome_entropy/orf/types.py
@@ -20,7 +20,8 @@ class OrfRecord:
         table_id: NCBI genetic code table ID used
         has_start_codon: Whether the source amino-acid string contains ``M``
         has_stop_codon: Whether the source amino-acid string contains ``*``
-        in_genbank: Whether the C-terminal GenBank CDS heuristic matched this ORF
+        in_genbank: Whether the coordinate-anchored GenBank CDS matcher matched
+            this ORF
     """
 
     parent_id: str

--- a/src/genome_entropy/pipeline/runner.py
+++ b/src/genome_entropy/pipeline/runner.py
@@ -138,7 +138,10 @@ def run_pipeline(
         if genbank_file:
             logger.info("Reading GenBank file...")
             sequences = read_genbank(genbank_file)
-            genbank_cds_list = extract_cds_features(genbank_file)
+            genbank_cds_list = extract_cds_features(
+                genbank_file,
+                pipeline_table_id=table_id,
+            )
             logger.info("Extracted %d CDS features from GenBank", len(genbank_cds_list))
 
             # If input_fasta is also provided, use it for sequences instead

--- a/tests/test_genbank.py
+++ b/tests/test_genbank.py
@@ -1,17 +1,24 @@
-"""Tests for GenBank file parsing and CDS matching functionality."""
+"""Tests for GenBank parsing and coordinate-anchored CDS matching."""
 
 import tempfile
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 import pytest
 
 from genome_entropy.io.genbank import (
+    MIN_CDS_OVERLAP_FRACTION,
+    MIN_SHARED_AA_IDENTITY,
+    CodingInterval,
     GenBankCDS,
     amino_acids_are_compatible,
-    compatible_c_terminal_suffix,
+    calculate_interval_overlap,
+    coding_phase_is_compatible,
+    evaluate_orf_genbank_cds_match,
     extract_cds_features,
     match_orf_to_genbank_cds,
+    normalise_orf_coordinates,
+    normalise_protein_sequence,
     orf_matches_genbank_cds,
     read_genbank,
 )
@@ -19,8 +26,8 @@ from genome_entropy.orf.types import OrfRecord
 
 
 def create_test_genbank_file() -> str:
-    """Create a minimal GenBank file for testing."""
-    genbank_content = """LOCUS       TEST_SEQ                 300 bp    DNA     linear   BCT 01-JAN-2024
+    """Create a minimal file with qualifier and fallback CDS translations."""
+    genbank_content = """LOCUS       TEST_SEQ                  30 bp    DNA     linear   BCT 01-JAN-2024
 DEFINITION  Test sequence for GenBank parsing.
 ACCESSION   TEST_SEQ
 VERSION     TEST_SEQ.1
@@ -29,25 +36,19 @@ SOURCE      Test organism
   ORGANISM  Test organism
             Bacteria.
 FEATURES             Location/Qualifiers
-     source          1..300
+     source          1..30
                      /organism="Test organism"
-     CDS             10..100
+     CDS             2..10
+                     /codon_start=1
+                     /transl_table=15
+                     /locus_tag="WITH_TRANSLATION"
+                     /translation="MK*"
+     CDS             complement(21..29)
                      /codon_start=1
                      /transl_table=11
-                     /product="test protein 1"
-                     /translation="MKSLLTSLAVVSGFLATCVAETKQEQ"
-     CDS             complement(150..250)
-                     /codon_start=1
-                     /transl_table=11
-                     /product="test protein 2"
-                     /translation="MQLLVLSCGQEDPKHLLKLRQF"
+                     /locus_tag="FALLBACK_TRANSLATION"
 ORIGIN
-        1 atgaaatccc ttctgacttc cctcgctgtc gtctccggct tcctcgccac ctgcgtggcc
-       61 gagaccaagc aggagcagtg atagctcgat tatcgatcga tcgatcgatc gatcgatcga
-      121 tcgatcgatc gatcgatcga tcgatcgatc tcgaaacgca gtttaaactt gagcaggcgc
-      181 ttgaacttgg tctcgttcag agcgccgctg agcagcagca tgacgtagct agctagctag
-      241 ctagctagct gtcaatacgg atcgatcgac gtatcagtac ggacatgcat acgtacgtac
-      301
+        1 aatgaaataa cccccccccc ttatttcat c
 //
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".gb", delete=False) as tmp:
@@ -55,79 +56,38 @@ ORIGIN
         return tmp.name
 
 
-def test_read_genbank() -> None:
-    """Test reading DNA sequences from GenBank file."""
-    genbank_file = create_test_genbank_file()
-
-    try:
-        sequences = read_genbank(genbank_file)
-
-        assert len(sequences) == 1
-        assert "TEST_SEQ.1" in sequences
-
-        # Check that sequence is uppercase
-        seq = sequences["TEST_SEQ.1"]
-        assert seq == seq.upper()
-        assert len(seq) == 300
-    finally:
-        Path(genbank_file).unlink(missing_ok=True)
-
-
-def test_read_genbank_nonexistent_file() -> None:
-    """Test that reading nonexistent GenBank file raises FileNotFoundError."""
-    with pytest.raises(FileNotFoundError):
-        read_genbank("/nonexistent/file.gb")
-
-
-def test_extract_cds_features() -> None:
-    """Test extracting CDS features from GenBank file."""
-    genbank_file = create_test_genbank_file()
-
-    try:
-        cds_features = extract_cds_features(genbank_file)
-
-        assert len(cds_features) == 2
-
-        # Check first CDS (forward strand)
-        cds1 = cds_features[0]
-        assert cds1.parent_id == "TEST_SEQ.1"
-        assert cds1.start == 9  # 0-based
-        assert cds1.end == 100  # exclusive
-        assert cds1.strand == "+"
-        assert cds1.protein_sequence == "MKSLLTSLAVVSGFLATCVAETKQEQ"
-
-        # Check second CDS (reverse strand)
-        cds2 = cds_features[1]
-        assert cds2.parent_id == "TEST_SEQ.1"
-        assert cds2.start == 149  # 0-based
-        assert cds2.end == 250  # exclusive
-        assert cds2.strand == "-"
-        assert cds2.protein_sequence == "MQLLVLSCGQEDPKHLLKLRQF"
-    finally:
-        Path(genbank_file).unlink(missing_ok=True)
-
-
 def make_orf(
     sequence: str,
     *,
     parent_id: str = "seq1",
-    start: int = 10,
-    end: int = 100,
+    genomic_start: int = 99,
+    genomic_end: Optional[int] = None,
     strand: Literal["+", "-"] = "+",
+    record_length: int = 5000,
+    orf_id: str = "orf1",
+    table_id: int = 11,
 ) -> OrfRecord:
-    """Create an ORF with get_orfs-style one-based inclusive coordinates."""
+    """Create an ORF from a desired zero-based, half-open genomic interval."""
+    if genomic_end is None:
+        genomic_end = genomic_start + 3 * len(normalise_protein_sequence(sequence))
+    if strand == "+":
+        start = genomic_start + 1
+        end = genomic_end
+    else:
+        start = record_length - genomic_end + 1
+        end = record_length - genomic_start
     return OrfRecord(
         parent_id=parent_id,
-        orf_id="orf1",
+        orf_id=orf_id,
         start=start,
         end=end,
         strand=strand,
         frame=1,
-        nt_sequence="ATG",
+        nt_sequence="",
         aa_sequence=sequence,
-        table_id=11,
-        has_start_codon=True,
-        has_stop_codon=True,
+        table_id=table_id,
+        has_start_codon="M" in sequence,
+        has_stop_codon="*" in sequence,
     )
 
 
@@ -135,52 +95,397 @@ def make_cds(
     sequence: str,
     *,
     parent_id: str = "seq1",
-    start: int = 9,
-    end: int = 100,
-    strand: str = "+",
+    start: int = 99,
+    end: Optional[int] = None,
+    strand: Literal["+", "-"] = "+",
+    record_length: int = 5000,
+    feature_id: str = "CDS_1",
+    translation_table: int = 11,
+    partial: bool = False,
 ) -> GenBankCDS:
-    """Create a CDS with Biopython-style zero-based half-open coordinates."""
-    return GenBankCDS(parent_id, start, end, strand, sequence)
-
-
-@pytest.mark.parametrize(
-    ("orf_sequence", "cds_sequence"),
-    [
-        ("MABCDEFGHIJK", "MABCDEFGHIJK"),
-        ("MABCDEFGHIJK", "XABCDEFGHIJK"),
-        ("MABCDEFGHIJK", "XDEFGHIJK"),
-        ("XDEFGHIJK", "MABCDEFGHIJK"),
-        ("MABCDEFGHIJK*", "MABCDEFGHIJK"),
-        ("MABCDEFGHIJK", "MABCDEFGHIJK*"),
-        (" MABCD EFGHIJK* ", "mabcdefghijk*"),
-    ],
-)
-def test_orf_matches_genbank_cds_valid_c_terminal_matches(
-    orf_sequence: str,
-    cds_sequence: str,
-) -> None:
-    """Match identical, alternative-start, suffix, stop, case, and space forms."""
-    assert orf_matches_genbank_cds(
-        make_orf(orf_sequence),
-        make_cds(cds_sequence),
+    """Create a CDS with zero-based, half-open genomic coordinates."""
+    if end is None:
+        end = start + 3 * len(normalise_protein_sequence(sequence))
+    return GenBankCDS(
+        parent_id,
+        start,
+        end,
+        strand,
+        sequence,
+        record_length=record_length,
+        feature_id=feature_id,
+        translation_table=translation_table,
+        partial=partial,
     )
 
 
+def test_read_genbank() -> None:
+    """Read sequences with uppercase bases and versioned record identifiers."""
+    path = create_test_genbank_file()
+    try:
+        sequences = read_genbank(path)
+        assert list(sequences) == ["TEST_SEQ.1"]
+        assert sequences["TEST_SEQ.1"].isupper()
+        assert len(sequences["TEST_SEQ.1"]) == 30
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_read_genbank_nonexistent_file() -> None:
+    """A missing input file is reported directly."""
+    with pytest.raises(FileNotFoundError):
+        read_genbank("/nonexistent/file.gb")
+
+
+def test_extract_cds_uses_qualifier_and_fallback_translations() -> None:
+    """Prefer /translation and otherwise translate the feature-specific DNA."""
+    path = create_test_genbank_file()
+    try:
+        first, second = extract_cds_features(path)
+        assert first.feature_id == "WITH_TRANSLATION"
+        assert first.protein_sequence == "MK*"
+        assert first.translation_table == 15
+        assert first.record_length == 30
+        assert (first.start, first.end, first.strand) == (1, 10, "+")
+
+        assert second.feature_id == "FALLBACK_TRANSLATION"
+        assert second.protein_sequence == "MK*"
+        assert second.translation_table == 11
+        assert (second.start, second.end, second.strand) == (20, 29, "-")
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_codon_start_is_applied_to_interval_and_fallback_translation() -> None:
+    """codon_start shifts the biological coding start before translation."""
+    content = """LOCUS       CODON_START               10 bp    DNA     linear   BCT 01-JAN-2024
+ACCESSION   CODON_START
+VERSION     CODON_START.1
+FEATURES             Location/Qualifiers
+     CDS             1..10
+                     /codon_start=2
+                     /transl_table=11
+                     /locus_tag="OFFSET"
+ORIGIN
+        1 aatgaaataa
+//
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".gb", delete=False) as tmp:
+        tmp.write(content)
+        path = tmp.name
+    try:
+        cds = extract_cds_features(path)[0]
+        assert (cds.start, cds.end, cds.codon_start) == (1, 10, 2)
+        assert cds.protein_sequence == "MK*"
+        orf = make_orf(
+            "MK*",
+            parent_id="CODON_START.1",
+            genomic_start=1,
+            genomic_end=10,
+            record_length=10,
+        )
+        assert orf_matches_genbank_cds(orf, cds)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+    ("source_qualifier", "pipeline_table", "expected_table"),
+    [
+        ("                     /transl_table=15\n", 11, 15),
+        ("", 15, 15),
+    ],
+)
+def test_translation_table_fallback_order(
+    source_qualifier: str,
+    pipeline_table: int,
+    expected_table: int,
+) -> None:
+    """A record/source table precedes the pipeline table for fallback translation."""
+    content = f"""LOCUS       TABLE_FALLBACK              6 bp    DNA     linear   BCT 01-JAN-2024
+ACCESSION   TABLE_FALLBACK
+VERSION     TABLE_FALLBACK.1
+FEATURES             Location/Qualifiers
+     source          1..6
+{source_qualifier}     CDS             1..6
+                     /locus_tag="TABLE_CDS"
+ORIGIN
+        1 atgtag
+//
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".gb", delete=False) as tmp:
+        tmp.write(content)
+        path = tmp.name
+    try:
+        cds = extract_cds_features(path, pipeline_table_id=pipeline_table)[0]
+        assert cds.translation_table == expected_table
+        assert cds.protein_sequence == "MQ"
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_partial_simple_cds_can_match() -> None:
+    """A safe contiguous partial location retains its boundary information."""
+    content = """LOCUS       PARTIAL                    10 bp    DNA     linear   BCT 01-JAN-2024
+ACCESSION   PARTIAL
+VERSION     PARTIAL.1
+FEATURES             Location/Qualifiers
+     CDS             <2..10
+                     /locus_tag="PARTIAL_CDS"
+                     /translation="MK*"
+ORIGIN
+        1 aatgaaataa
+//
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".gb", delete=False) as tmp:
+        tmp.write(content)
+        path = tmp.name
+    try:
+        cds = extract_cds_features(path)[0]
+        assert cds.partial
+        orf = make_orf(
+            "MK*",
+            parent_id="PARTIAL.1",
+            genomic_start=1,
+            genomic_end=10,
+            record_length=10,
+        )
+        assert orf_matches_genbank_cds(orf, cds)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_compound_location_is_skipped() -> None:
+    """Joined and origin-crossing CDS locations are not silently flattened."""
+    content = """LOCUS       JOINED                     30 bp    DNA     circular BCT 01-JAN-2024
+ACCESSION   JOINED
+VERSION     JOINED.1
+FEATURES             Location/Qualifiers
+     CDS             join(25..30,1..6)
+                     /locus_tag="JOINED_CDS"
+                     /translation="MKK"
+ORIGIN
+        1 atgaaaaaaa aaaaaaaaaa aaaaaaataa
+//
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".gb", delete=False) as tmp:
+        tmp.write(content)
+        path = tmp.name
+    try:
+        assert extract_cds_features(path) == []
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_coordinate_normalisation_on_both_strands() -> None:
+    """Convert public ORF coordinates to one genomic coordinate convention."""
+    forward = make_orf("MABC", genomic_start=99, genomic_end=111)
+    reverse = make_orf(
+        "MABC",
+        genomic_start=399,
+        genomic_end=411,
+        strand="-",
+        record_length=1000,
+    )
+    assert normalise_orf_coordinates(forward, 1000) == CodingInterval(99, 111, "+")
+    assert normalise_orf_coordinates(reverse, 1000) == CodingInterval(399, 411, "-")
+
+
+def test_invalid_coding_intervals_are_rejected() -> None:
+    """Central interval validation rejects negative and empty intervals."""
+    with pytest.raises(ValueError):
+        CodingInterval(-1, 3, "+")
+    with pytest.raises(ValueError):
+        CodingInterval(3, 3, "+")
+
+
+def test_exact_full_length_match() -> None:
+    """An existing exact same-locus match remains successful."""
+    sequence = "MABCDEFGHI"
+    assert orf_matches_genbank_cds(make_orf(sequence), make_cds(sequence))
+
+
+def test_alternative_start_and_contained_cds_match() -> None:
+    """A same-frame N-terminal extension does not prevent a CDS match."""
+    shared = "M" + "A" * 99
+    extension = "QRSKLMNP"
+    orf = make_orf(
+        extension + shared,
+        genomic_start=75,
+        genomic_end=399,
+    )
+    cds = make_cds(shared, start=99, end=399)
+    assert orf_matches_genbank_cds(orf, cds)
+
+
+def test_shorter_cds_contained_within_longer_orf_matches() -> None:
+    """Both terminal boundaries may differ when overlap remains substantial."""
+    core = "A" * 100
+    orf = make_orf("QQQQQ" + core + "RRRRR", genomic_start=84, genomic_end=414)
+    cds = make_cds(core, start=99, end=399)
+    assert orf_matches_genbank_cds(orf, cds)
+
+
 @pytest.mark.parametrize(
     ("orf_sequence", "cds_sequence"),
     [
-        ("MABCDEFGHIJK", "MABXDEFGHIJK"),
-        ("MABXDEFGHIJK", "MABCDEFGHIJK"),
-        ("MABCDEFGHIJK", "MABCXEFGHIJK"),
-        ("MABCDEFGHIJK", "MAXCDXFGHIXK"),
+        ("MABCDKFGHI", "MABCDXFGHI"),
+        ("MABCDXFGHI", "MABCDKFGHI"),
+        ("MABCDKFGHI*", "MABCDXFGHI"),
+        ("MABCDKFGHI", "MABCDXFGHI*"),
+        (" mabcdkfghi* ", "MABCDXFGHI"),
     ],
 )
-def test_orf_matches_genbank_cds_accepts_aligned_x_residues(
+def test_x_terminal_stop_case_and_whitespace_are_supported(
     orf_sequence: str,
     cds_sequence: str,
 ) -> None:
-    """An aligned X is compatible in either sequence, including repeatedly."""
-    assert orf_matches_genbank_cds(make_orf(orf_sequence), make_cds(cds_sequence))
+    """X is an aligned wildcard and terminal formatting is ignored."""
+    assert orf_matches_genbank_cds(
+        make_orf(orf_sequence, genomic_end=129),
+        make_cds(cds_sequence, end=129),
+    )
+
+
+def test_cds_specific_translation_table_does_not_need_pipeline_table() -> None:
+    """Matching preserves a feature's annotation-provider translation."""
+    orf = make_orf("MPEPTIDE", table_id=11)
+    cds = make_cds("MPEPTIDE", translation_table=15)
+    assert cds.translation_table == 15
+    assert orf_matches_genbank_cds(orf, cds)
+
+
+def test_one_codon_difference_at_each_end_matches() -> None:
+    """Coordinate alignment tolerates table-dependent terminal differences."""
+    shared = "A" * 100
+    orf = make_orf("V" + shared, genomic_start=96, genomic_end=399)
+    cds = make_cds(shared + "Q", start=99, end=402, translation_table=15)
+    result = evaluate_orf_genbank_cds_match(orf, cds)
+    assert result.matched
+    assert result.compared_aa == 100
+    assert result.overlap_fraction > 0.99
+
+
+def test_reverse_strand_alternative_start_matches() -> None:
+    """Phase and protein offsets follow high-to-low biological translation."""
+    shared = "M" + "A" * 99
+    orf = make_orf(
+        "Q" * 10 + shared,
+        genomic_start=99,
+        genomic_end=429,
+        strand="-",
+        record_length=1000,
+    )
+    cds = make_cds(
+        shared,
+        start=99,
+        end=399,
+        strand="-",
+        record_length=1000,
+    )
+    assert orf_matches_genbank_cds(orf, cds)
+
+
+def test_same_coordinates_different_strands_do_not_match() -> None:
+    """Strand is a mandatory genomic constraint."""
+    assert not orf_matches_genbank_cds(
+        make_orf("MABCDEFGHI", strand="+"),
+        make_cds("MABCDEFGHI", strand="-"),
+    )
+
+
+def test_different_parent_sequences_do_not_match() -> None:
+    """Coordinates cannot identify the same gene on different records."""
+    assert not orf_matches_genbank_cds(
+        make_orf("MABCDEFGHI", parent_id="one"),
+        make_cds("MABCDEFGHI", parent_id="two"),
+    )
+
+
+def test_strong_overlap_in_different_codon_phase_does_not_match() -> None:
+    """Nearly identical intervals offset by one nucleotide fail phase checking."""
+    orf = make_orf("A" * 100, genomic_start=99, genomic_end=399)
+    cds = make_cds("A" * 99, start=100, end=397)
+    result = evaluate_orf_genbank_cds_match(orf, cds)
+    assert not result.matched
+    assert not result.phase_compatible
+    assert result.reason == "different codon phase"
+
+
+@pytest.mark.parametrize(
+    ("overlap_nt", "expected"),
+    [
+        (270, True),
+        (267, False),
+    ],
+)
+def test_overlap_threshold_boundary(overlap_nt: int, expected: bool) -> None:
+    """Exactly 90% overlap passes while the next whole codon below it fails."""
+    orf = make_orf("A" * 100, genomic_start=99, genomic_end=399)
+    cds_start = 399 - overlap_nt
+    cds = make_cds("A" * 100, start=cds_start, end=cds_start + 300)
+    result = evaluate_orf_genbank_cds_match(orf, cds)
+    assert result.overlap_fraction == pytest.approx(overlap_nt / 300)
+    assert result.matched is expected
+    assert MIN_CDS_OVERLAP_FRACTION == 0.90
+
+
+def test_conserved_domain_without_near_complete_overlap_does_not_match() -> None:
+    """A shared local domain cannot override insufficient genomic overlap."""
+    orf = make_orf("A" * 100, genomic_start=99, genomic_end=399)
+    cds = make_cds("A" * 100, start=309, end=609)
+    assert not orf_matches_genbank_cds(orf, cds)
+
+
+@pytest.mark.parametrize(
+    ("mismatches", "expected"),
+    [
+        (2, True),
+        (3, False),
+    ],
+)
+def test_identity_threshold_boundary(mismatches: int, expected: bool) -> None:
+    """Exactly 98% compatibility passes and 97% fails."""
+    orf_sequence = "A" * 100
+    cds_sequence = "B" * mismatches + "A" * (100 - mismatches)
+    result = evaluate_orf_genbank_cds_match(
+        make_orf(orf_sequence),
+        make_cds(cds_sequence),
+    )
+    assert result.identity == pytest.approx((100 - mismatches) / 100)
+    assert result.matched is expected
+    assert MIN_SHARED_AA_IDENTITY == 0.98
+
+
+def test_high_overlap_with_poor_identity_does_not_match() -> None:
+    """Genomic agreement cannot compensate for unrelated translations."""
+    assert not orf_matches_genbank_cds(
+        make_orf("A" * 100),
+        make_cds("R" * 100),
+    )
+
+
+def test_translation_must_cover_coordinate_aligned_overlap() -> None:
+    """A short local protein fragment cannot match a much larger interval."""
+    orf = make_orf("A" * 100, genomic_start=99, genomic_end=399)
+    cds = make_cds("A" * 20, start=99, end=399)
+    result = evaluate_orf_genbank_cds_match(orf, cds)
+    assert not result.matched
+    assert "do not cover" in result.reason
+
+
+def test_existing_true_negative_remains_false() -> None:
+    """An unrelated same-coordinate protein remains unmatched."""
+    orf = make_orf("MABCDEFGHI")
+    cds_list = [make_cds("MRRRRRRRRR"), make_cds("MABCDEFGHI", parent_id="other")]
+    assert not match_orf_to_genbank_cds(orf, cds_list)
+
+
+def test_match_orf_to_genbank_cds_checks_later_candidates() -> None:
+    """A failed candidate does not prevent a later valid CDS match."""
+    orf = make_orf("MABCDEFGHI")
+    candidates = [make_cds("MRRRRRRRRR"), make_cds("MABXDEFGHI")]
+    assert match_orf_to_genbank_cds(orf, candidates)
 
 
 @pytest.mark.parametrize(
@@ -189,13 +494,8 @@ def test_orf_matches_genbank_cds_accepts_aligned_x_residues(
         ("A", "A", True),
         ("X", "K", True),
         ("K", "X", True),
-        ("X", "X", True),
-        ("B", "B", True),
         ("B", "D", False),
         ("Z", "Q", False),
-        ("J", "L", False),
-        ("U", "C", False),
-        ("O", "K", False),
         ("*", "X", False),
     ],
 )
@@ -204,176 +504,97 @@ def test_amino_acids_are_compatible(
     residue_b: str,
     expected: bool,
 ) -> None:
-    """Only X acts as a wildcard; other ambiguity symbols stay specific."""
+    """Only X is a wildcard; other ambiguous symbols remain specific."""
     assert amino_acids_are_compatible(residue_a, residue_b) is expected
 
 
-def test_compatible_c_terminal_suffix_remains_anchored() -> None:
-    """Compatibility does not enable internal, prefix, or indel matching."""
-    assert compatible_c_terminal_suffix("CDEFX", "ABCDEFK")
-    assert not compatible_c_terminal_suffix("ABCDE", "ABCDEXK")
-    assert not compatible_c_terminal_suffix("ABDE", "ABCDEFG")
+def test_interval_overlap_and_phase_helpers() -> None:
+    """Helper calculations expose their zero-based genomic semantics."""
+    first = CodingInterval(99, 399, "+")
+    second = CodingInterval(129, 399, "+")
+    assert calculate_interval_overlap(first, second) == (270, 1.0)
+    assert coding_phase_is_compatible(first, second)
+    assert not coding_phase_is_compatible(first, CodingInterval(100, 400, "+"))
 
 
-@pytest.mark.parametrize(
-    ("orf_sequence", "cds_sequence"),
-    [
-        ("MABCDEFGHIJK", "MABCDEFGHIJY"),
-        ("MABCDEFGHIJK", "MABCYEFGHIJK"),
-        ("MABCDEFGHIJK", "XEFGHIJ"),
-        ("MABCDEFGHIJK", "MABCDE"),
-        ("MABCDEFGHIJK", "MABCDEFGHIJ"),
-        ("MABCDEFGHIJK", "MABCDXEFGHIJK"),
-        ("MABCDEFGHIJK", "MABCXFGHIJK"),
-        ("MABC*DEFGHIJK", "MABCDEFGHIJK"),
-    ],
-)
-def test_orf_matches_genbank_cds_rejects_non_terminal_matches(
-    orf_sequence: str,
-    cds_sequence: str,
-) -> None:
-    """Reject final mismatches, region mismatches, substrings, and prefixes."""
-    assert not orf_matches_genbank_cds(
-        make_orf(orf_sequence),
-        make_cds(cds_sequence),
+def test_kj206559_orf110_regression() -> None:
+    """KJ206559 orf110 matches CDS_0138 across 8-aa extension and four Xs."""
+    shared = list("M" + "A" * 703)
+    cds_shared = shared.copy()
+    for position in (80, 320, 350, 370):
+        cds_shared[position] = "X"
+    orf = make_orf(
+        "SSVKDERY" + "".join(shared),
+        parent_id="KJ206559",
+        genomic_start=99452,
+        genomic_end=101591,
+        record_length=142096,
+        orf_id="orf110",
     )
-
-
-def test_orf_matches_genbank_cds_requires_same_stop_coordinate() -> None:
-    """Matching sequences at different biological stops are distinct proteins."""
-    assert not orf_matches_genbank_cds(
-        make_orf("MABCDEFGHIJK", end=100),
-        make_cds("MABCDEFGHIJK", end=101),
+    cds = make_cds(
+        "".join(cds_shared) + "*",
+        parent_id="KJ206559",
+        start=99476,
+        end=101591,
+        record_length=142096,
+        feature_id="KJ206559_CDS_0138",
     )
+    result = evaluate_orf_genbank_cds_match(orf, cds)
+    assert result.matched
+    assert result.wildcard_aa == 4
+    assert result.compared_aa == 704
 
 
-def test_orf_matches_genbank_cds_requires_same_strand() -> None:
-    """Matching sequences on different strands are distinct proteins."""
-    assert not orf_matches_genbank_cds(
-        make_orf("MABCDEFGHIJK", strand="+"),
-        make_cds("MABCDEFGHIJK", strand="-"),
+def test_px673949_orf76_regression() -> None:
+    """PX673949.1 orf76 matches CDS_0126 across 37-aa extension and four Xs."""
+    shared = list("M" + "A" * 691)
+    cds_shared = shared.copy()
+    for position in (220, 280, 400, 650):
+        cds_shared[position] = "X"
+    orf = make_orf(
+        "Q" * 37 + "".join(shared),
+        parent_id="PX673949.1",
+        genomic_start=84411,
+        genomic_end=86601,
+        record_length=100813,
+        orf_id="orf76",
     )
-
-
-def test_orf_matches_genbank_cds_requires_same_parent_sequence() -> None:
-    """Coordinates on different parent sequences do not identify one protein."""
-    assert not orf_matches_genbank_cds(
-        make_orf("MABCDEFGHIJK", parent_id="seq1"),
-        make_cds("MABCDEFGHIJK", parent_id="seq2"),
+    cds = make_cds(
+        "".join(cds_shared) + "*",
+        parent_id="PX673949.1",
+        start=84522,
+        end=86601,
+        record_length=100813,
+        feature_id="PX673949.1_CDS_0126",
     )
+    result = evaluate_orf_genbank_cds_match(orf, cds)
+    assert result.matched
+    assert result.wildcard_aa == 4
+    assert result.compared_aa == 692
 
 
-def test_orf_matches_genbank_cds_uses_reverse_strand_low_coordinate() -> None:
-    """A reverse-strand stop maps from one-based ORF to zero-based CDS start."""
-    orf = make_orf("MABCDEFGHIJK", start=150, end=250, strand="-")
-
-    assert orf_matches_genbank_cds(
-        orf,
-        make_cds("MABCDEFGHIJK", start=149, end=250, strand="-"),
+def test_nc055901_orf52_regression() -> None:
+    """NC_055901 orf52 matches table-15 CDS_0090 across shifted termini."""
+    shared = "A" * 626
+    orf = make_orf(
+        "V" + shared,
+        parent_id="NC_055901",
+        genomic_start=92434,
+        genomic_end=94318,
+        record_length=94826,
+        orf_id="orf52",
+        table_id=11,
     )
-    assert not orf_matches_genbank_cds(
-        orf,
-        make_cds("MABCDEFGHIJK", start=150, end=250, strand="-"),
+    cds = make_cds(
+        shared + "Q*",
+        parent_id="NC_055901",
+        start=92437,
+        end=94321,
+        record_length=94826,
+        feature_id="NC_055901_CDS_0090",
+        translation_table=15,
     )
-
-
-def test_mf580763_ambiguous_residue_regression() -> None:
-    """MF580763 orf5 matches CDS 0014 despite its K/X ambiguity."""
-    shared_suffix = "MQIWIHDKSMRKVCALNNEIPGMLPYSNSQWHPYLEY"
-    orf_suffix = shared_suffix + "STFDFTIPKIVNGKLHDDLKYINDQMHVSFGGAKSVEWYLRN"
-    cds_suffix = shared_suffix + "STFDFTIPKIVNGKLHDDLKYINDQMHVSFGGAXSVEWYLRN"
-    orf5 = make_orf(
-        "NFLEGAFCL" + orf_suffix,
-        parent_id="MF580763",
-        start=14920,
-        end=18216,
-    )
-    cds_0014 = make_cds(
-        cds_suffix,
-        parent_id="MF580763",
-        start=14946,
-        end=18216,
-    )
-
-    assert orf_matches_genbank_cds(orf5, cds_0014)
-
-
-@pytest.mark.parametrize(
-    ("orf_sequence", "cds_sequence"),
-    [
-        ("", "MABC"),
-        ("MABC", ""),
-        ("M", "MABC"),
-        ("MABC", "M"),
-        ("*", "MABC"),
-        ("MABC", "*"),
-    ],
-)
-def test_orf_matches_genbank_cds_rejects_empty_comparison_sequences(
-    orf_sequence: str,
-    cds_sequence: str,
-) -> None:
-    """Empty and one-residue proteins cannot establish a C-terminal match."""
-    assert not orf_matches_genbank_cds(
-        make_orf(orf_sequence),
-        make_cds(cds_sequence),
-    )
-
-
-def test_match_orf_to_genbank_cds_matches_any_eligible_cds() -> None:
-    """Preserve successful matching when the eligible CDS is later in the list."""
-    orf = make_orf("MKSLLTSLAVVSGFLATCVAETKQEQ")
-    cds_list = [
-        make_cds("MAAAAAAAAAAAAAAAAAAAAAAAAA", end=100),
-        make_cds("XKSLLTSLAVVSGFLATCVAETKQEQ", end=100),
-    ]
-
-    assert match_orf_to_genbank_cds(orf, cds_list)
-    assert not match_orf_to_genbank_cds(orf, [])
-
-
-def test_extracted_forward_and_reverse_cds_match_detected_orfs() -> None:
-    """Regression-test parsed CDS coordinates with partial and altered starts."""
-    genbank_file = create_test_genbank_file()
-
-    try:
-        forward_cds, reverse_cds = extract_cds_features(genbank_file)
-        forward_cds.protein_sequence = "XETKQEQ"
-        reverse_cds.protein_sequence = "XQEDPKHLLKLRQF"
-
-        forward_orf = make_orf(
-            "MKSLLTSLAVVSGFLATCVAETKQEQ",
-            parent_id="TEST_SEQ.1",
-            start=10,
-            end=100,
-            strand="+",
-        )
-        reverse_orf = make_orf(
-            "MQLLVLSCGQEDPKHLLKLRQF",
-            parent_id="TEST_SEQ.1",
-            start=150,
-            end=250,
-            strand="-",
-        )
-
-        assert match_orf_to_genbank_cds(forward_orf, [forward_cds])
-        assert match_orf_to_genbank_cds(reverse_orf, [reverse_cds])
-    finally:
-        Path(genbank_file).unlink(missing_ok=True)
-
-
-def test_genbank_cds_dataclass() -> None:
-    """Test GenBankCDS dataclass creation."""
-    cds = GenBankCDS(
-        parent_id="TEST_SEQ",
-        start=10,
-        end=100,
-        strand="+",
-        protein_sequence="MKSLLTSLA",
-    )
-
-    assert cds.parent_id == "TEST_SEQ"
-    assert cds.start == 10
-    assert cds.end == 100
-    assert cds.strand == "+"
-    assert cds.protein_sequence == "MKSLLTSLA"
+    result = evaluate_orf_genbank_cds_match(orf, cds)
+    assert result.matched
+    assert result.compared_aa == 626
+    assert result.identity == 1.0


### PR DESCRIPTION
## Summary

Fixes false-negative `in_genbank` assignments by replacing strict stop-coordinate/C-terminal matching with a coordinate-normalised, strand-aware, frame-aware comparison of substantially overlapping coding regions.

The new logic:

- converts one-based inclusive ORF coordinates and Biopython locations to zero-based, half-open genomic intervals;
- correctly maps negative-strand ORF coordinates from the reverse-complement axis;
- requires the same record, strand, codon phase, and substantial genomic overlap;
- compares only amino acids implied by shared genomic codons, without local alignment or indels;
- treats aligned `X` residues as unknown amino acids and ignores terminal `*`;
- supports CDS-specific translation tables and `codon_start`;
- translates feature nucleotides when `/translation` is absent;
- skips compound/origin-crossing CDS locations with a debug reason rather than flattening them;
- adds structured debug diagnostics without logging sequence content.

## Confirmed regressions fixed

- `KJ206559` `orf110` ↔ `KJ206559_CDS_0138`: 704 aligned amino acids, four wildcard positions, identity 1.0
- `PX673949.1` `orf76` ↔ `PX673949.1_CDS_0126`: 692 aligned amino acids, four wildcard positions, identity 1.0
- `NC_055901` `orf52` ↔ `NC_055901_CDS_0090`: 626 aligned amino acids, table 11 versus table 15, overlap 0.9984, identity 1.0

## Before/after validation on supplied records

| Genome | Total ORFs | Before true | Before false | After true | After false | Newly matched | No longer matched |
|---|---:|---:|---:|---:|---:|---:|---:|
| KJ206559 | 210 | 123 | 87 | 169 | 41 | 46 | 0 |
| PX673949.1 | 447 | 13 | 434 | 122 | 325 | 109 | 0 |
| NC_055901 | 164 | 30 | 134 | 110 | 54 | 80 | 0 |

Every newly matched ORF had exactly one eligible CDS candidate. Across the additional calls, minimum genomic overlap was 0.9251 and minimum compatible amino-acid identity was 0.9855. The large KJ206559 and NC_055901 recoveries are mostly negative-strand calls previously affected by reverse-coordinate handling; PX673949.1 recoveries are predominantly exact/wildcard-compatible forward-strand alignments.

## Matching thresholds

- minimum genomic overlap fraction: `0.90` of the shorter interval, requiring near-complete locus agreement while allowing alternative starts and small terminal differences;
- minimum shared amino-acid identity: `0.98`, strict enough to reject unrelated translations while tolerating sparse annotation/provider differences;
- translation coverage: all shared codons except one possible terminal stop codon.

Boundary behavior for both thresholds is regression-tested.

## Validation

- focused GenBank tests: `43 passed`
- complete `pytest`: `233 passed, 14 skipped` (expected optional dependency/integration skips)
- Black: passed for all changed Python files
- Ruff: passed for changed implementation and tests
- mypy: passed for all changed core source modules
- Sphinx HTML with warnings as errors: passed
- `git diff --check`: passed

Repository-wide Ruff was also run and reports 24 pre-existing findings in unrelated files. Repository-wide mypy remains blocked by pre-existing optional dependency/stub and configured-Python-versus-NumPy-stub issues; changed modules pass when checked directly.