### PR TITLE
Add mutual information for ModernProst structural states

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 `genome_entropy` quantifies Shannon entropy across biological representations derived from genomic DNA. It finds open reading frames (ORFs), translates proteins, predicts structural-state encodings, and writes a non-redundant JSON record for downstream analysis.
 
-Current multitask ModernProst models produce both Foldseek 3Di and 12-state (`12st`) encodings. The command remains named `encode3di` for compatibility. Legacy ModernProst and ProstT5 models produce 3Di only, with 12-state fields written as `null`.
+Current multitask ModernProst models produce both Foldseek 3Di and 12-state (`12st`) encodings. For those models, genome_entropy also reports the empirical mutual information between aligned 3Di and 12-state assignments in bits. The command remains named `encode3di` for compatibility. Legacy ModernProst and ProstT5 models produce 3Di only, with 12-state and mutual-information fields written as `null`.
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Current multitask ModernProst models produce both Foldseek 3Di and 12-state (`12
 - translation with [`pygenetic-code`](https://github.com/linsalrob/genetic_codes)
 - 3Di and optional 12-state prediction with ModernProst or ProstT5
 - raw Shannon entropy for DNA, protein, 3Di, and 12-state representations
+- raw 3Di--12-state mutual information for dual-head ModernProst outputs
 - CUDA, ROCm-through-PyTorch's CUDA API, Apple MPS, CPU, and multi-GPU encoding
 - optional XGBoost or PyTorch classification of whether an ORF matches a GenBank CDS
 
@@ -85,7 +86,7 @@ See the [model guide](https://genome-entropy.readthedocs.io/en/latest/models.htm
 
 ## Output and entropy
 
-The pipeline writes schema `2.1.0`, with features keyed by ORF identifier. Each feature contains location, DNA, protein, 3Di, optional 12-state, metadata, and raw entropy. JSON and JSON-gzip input are supported where documented.
+The pipeline writes schema `2.2.0`, with features keyed by ORF identifier. Each feature contains location, DNA, protein, 3Di, optional 12-state, metadata, raw entropy, and (when available) raw 3Di--12-state mutual information. JSON and JSON-gzip input are supported where documented.
 
 Normalised entropy is deliberately not serialised. Derive it downstream:
 

--- a/REFACTORING_SUMMARY.md
+++ b/REFACTORING_SUMMARY.md
@@ -5,11 +5,12 @@ This file records the migration from duplicated `orfs`, `proteins`, and
 current schema reference.
 
 The maintained [data-format documentation](docs/source/data_formats.rst)
-describes schema version `2.1.0`, 1-based inclusive coordinates, nullable
+describes schema version `2.2.0`, 1-based inclusive coordinates, nullable
 12-state fields, compression support, metadata, entropy units, and legacy-input
 compatibility. In particular, current output includes an alphabet size of 12
-and, for multitask ModernProst models, `twelve_state` and
-`twelve_state_entropy`. Standard JSON stores raw Shannon entropy only.
+and, for multitask ModernProst models, `twelve_state`,
+`twelve_state_entropy`, and `three_di_twelve_state_mutual_information`.
+Standard JSON stores raw Shannon entropy and raw structural mutual information.
 
 The refactoring's stable user-visible result is one record per ORF under
 `features`, with location, DNA, protein, structural encoding, metadata, and

--- a/docs/source/data_formats.rst
+++ b/docs/source/data_formats.rst
@@ -17,13 +17,13 @@ both (FASTA supplies sequences while GenBank supplies CDS annotations). GenBank
 Unified pipeline JSON
 ---------------------
 
-``run`` serialises schema ``2.1.0``. The top level is a list because one input
+``run`` serialises schema ``2.2.0``. The top level is a list because one input
 file can contain multiple sequence records. A compact representative record is:
 
 .. code-block:: json
 
    [{
-     "schema_version": "2.1.0",
+     "schema_version": "2.2.0",
      "input_id": "contig_1",
      "input_dna_length": 900,
      "dna_entropy_global": 1.97,
@@ -55,7 +55,8 @@ file can contain multiple sequence records. A compact representative record is:
            "dna_entropy": 1.8,
            "protein_entropy": 3.4,
            "three_di_entropy": 3.1,
-           "twelve_state_entropy": 2.7
+           "twelve_state_entropy": 2.7,
+           "three_di_twelve_state_mutual_information": 1.9
          }
        }
      }
@@ -152,6 +153,7 @@ Use theoretical sizes 4 for DNA, 20 for protein, 20 for 3Di, and 12 for
        normalise_protein_entropy,
        normalise_three_di_entropy,
        normalise_twelve_state_entropy,
+       mutual_information,
    )
 
    generic = normalise_entropy(raw_entropy, alphabet_size=20)
@@ -160,6 +162,24 @@ Use theoretical sizes 4 for DNA, 20 for protein, 20 for 3Di, and 12 for
 All helpers return ``None`` for missing entropy. The generic helper raises
 ``ValueError`` when a non-missing value is supplied with an alphabet size of one
 or less.
+
+Structural mutual information
+-----------------------------
+
+For dual-head ModernProst models, each residue has aligned 3Di and 12-state
+symbols. The output stores their empirical mutual information in raw bits:
+
+.. math::
+
+   I(X;Y) = \sum_x \sum_y p(x,y) \log_2\left(\frac{p(x,y)}{p(x)p(y)}\right)
+
+This measures how much information one structural-state encoding provides about
+the other across an ORF; it is not another entropy of either alphabet. No
+normalised mutual information is stored because several normalisations are
+reasonable. The intermediate 12 by 20 contingency table is not serialised;
+the aligned discrete argmax sequences already retain the underlying data.
+Legacy 3Di-only models write
+``three_di_twelve_state_mutual_information: null``.
 
 Intermediate and backward-compatible formats
 --------------------------------------------
@@ -173,6 +193,7 @@ sizes; its global DNA entropy is ``0.0`` because the original full contig is not
 available at that stage.
 
 The JSON writer converts in-memory legacy ``PipelineResult`` objects to unified
-schema 2.1. It does not provide a general command that migrates arbitrary legacy
+schema 2.2. Older schema 2.1 files remain readable and receive missing 12-state
+and mutual-information fields as ``null``. It does not provide a general command that migrates arbitrary legacy
 JSON dictionaries on disk. ML feature extraction accepts both unified and older
 pipeline layouts and treats absent 12-state features as missing values.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,8 +10,10 @@ content across representations derived from genomic DNA:
 
 Current multitask ModernProst models emit both 3Di and 12-state (``12st``)
 encodings. Legacy ModernProst and ProstT5 models emit 3Di only. Raw Shannon
-entropy is calculated for available representations; normalised entropy is a
-downstream derived value and is not stored in standard JSON.
+entropy is calculated for available representations. When both structural
+encodings are available, raw 3Di--12-state mutual information is also stored.
+Normalised entropy and mutual information are downstream derived values and are
+not stored in standard JSON.
 
 The pipeline calls the external ``get_orfs`` program for six-frame ORF discovery,
 uses ``pygenetic-code`` for translation, and supports FASTA or GenBank input.

--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -51,6 +51,10 @@ The neural network learns column medians from its training set, substitutes zero
 for an all-missing column, stores those imputation values, and reuses them for
 evaluation and prediction.
 
+The 3Di--12-state mutual-information output is deliberately not an ML feature
+yet. This keeps existing saved-model feature schemas unchanged while it is
+evaluated as a possible future feature.
+
 Splitting and reproducibility
 -----------------------------
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -60,6 +60,8 @@ Output semantics
 The additional 12-state head predicts 12 structural classes. In JSON, 12-state
 class IDs 0--11 are deterministically serialised as characters ``A``--``L``;
 these letters are storage symbols, not a published biological nomenclature.
+For dual-head output, genome_entropy also stores raw per-ORF mutual information
+in bits between the aligned discrete 3Di and 12-state sequences.
 
 For legacy models, structural records and unified pipeline output contain:
 
@@ -67,7 +69,8 @@ For legacy models, structural records and unified pipeline output contain:
 
    {
      "twelve_state": null,
-     "twelve_state_entropy": null
+     "twelve_state_entropy": null,
+     "three_di_twelve_state_mutual_information": null
    }
 
 Older JSON in which these fields are absent remains readable and is treated as

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -16,7 +16,8 @@ Complete pipeline
    genome_entropy run --input genome.fasta --output results.json
 
 The default ``gbouras13/modernprost-50M`` model predicts 3Di and 12-state
-encodings. The JSON contains raw entropy and uses unified schema 2.1.0.
+encodings. The JSON contains raw entropy plus raw 3Di--12-state mutual
+information when both encodings are available, and uses unified schema 2.2.0.
 
 GenBank input enables CDS matching:
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -38,6 +38,16 @@ The multitask ModernProst head also emits 12 classes serialised as ``A`` through
 ``L``. Legacy encoders expose missing 12-state values as ``None``/JSON ``null``.
 See :doc:`models` for model selection, provenance, and security.
 
+For a dual-head model, the pipeline also calculates the empirical mutual
+information between the aligned 3Di and 12-state assignments for each ORF. It
+is reported in raw bits and describes association between representations, not
+the diversity of either representation alone. Legacy models report ``null``;
+no normalised mutual information or contingency matrix is stored.
+
+.. math::
+
+   I(X;Y) = \sum_x \sum_y p(x,y) \log_2\left(\frac{p(x,y)}{p(x)p(y)}\right)
+
 Shannon entropy
 ---------------
 

--- a/docs/unified_output_format.md
+++ b/docs/unified_output_format.md
@@ -2,6 +2,6 @@
 
 The maintained schema reference is [`docs/source/data_formats.rst`](source/data_formats.rst) and is published as [Data formats, coordinates, and entropy](https://genome-entropy.readthedocs.io/en/latest/data_formats.html).
 
-Current pipeline output uses schema `2.1.0` and stores each ORF once under `features`. Coordinates are one-based and inclusive, matching `get_orfs` output. Each feature includes DNA, protein, 3Di, optional 12-state, metadata, and raw entropy. Legacy encoders serialise `twelve_state` and `twelve_state_entropy` as JSON `null`; missing fields in older JSON are treated as unavailable.
+Current pipeline output uses schema `2.2.0` and stores each ORF once under `features`. Coordinates are one-based and inclusive, matching `get_orfs` output. Each feature includes DNA, protein, 3Di, optional 12-state, metadata, raw entropy, and raw 3Di--12-state mutual information when available. Legacy encoders serialise `twelve_state`, `twelve_state_entropy`, and `three_di_twelve_state_mutual_information` as JSON `null`; missing fields in older JSON are treated as unavailable.
 
 Normalised entropy is downstream derived data and is not written to standard JSON. The maintained reference includes a complete compact example, intermediate record formats, gzip support, GenBank matching semantics, and compatibility limitations.

--- a/src/genome_entropy/cli/commands/entropy.py
+++ b/src/genome_entropy/cli/commands/entropy.py
@@ -29,7 +29,11 @@ def entropy_command(
     Computes entropy for DNA, ORF nucleotides, proteins, 3Di, and 12-state tokens.
     """
     try:
-        from ...entropy.shannon import calculate_entropies_for_sequences, EntropyReport
+        from ...entropy.shannon import (
+            EntropyReport,
+            calculate_entropies_for_sequences,
+            mutual_information,
+        )
         from ...io.jsonio import read_json, write_json
         from ...orf.types import OrfRecord
         from ...translate.translator import ProteinRecord
@@ -90,6 +94,15 @@ def entropy_command(
             if twelve_state_seqs
             else None
         )
+        three_di_twelve_state_mutual_information = (
+            {
+                td.protein.orf.orf_id: mutual_information(td.three_di, td.twelve_state)
+                for td in three_dis
+                if td.twelve_state is not None
+            }
+            if twelve_state_seqs
+            else None
+        )
 
         # Create report
         report = EntropyReport(
@@ -104,6 +117,9 @@ def entropy_command(
                 "twelve_state": TWELVE_STATE_ALPHABET_SIZE,
             },
             twelve_state_entropy=twelve_state_entropy,
+            three_di_twelve_state_mutual_information=(
+                three_di_twelve_state_mutual_information
+            ),
         )
 
         typer.echo(f"  Calculated entropy for {len(orf_nt_entropy)} sequence(s)")

--- a/src/genome_entropy/entropy/__init__.py
+++ b/src/genome_entropy/entropy/__init__.py
@@ -6,6 +6,7 @@ from .shannon import (
     normalise_protein_entropy,
     normalise_three_di_entropy,
     normalise_twelve_state_entropy,
+    mutual_information,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "normalise_protein_entropy",
     "normalise_three_di_entropy",
     "normalise_twelve_state_entropy",
+    "mutual_information",
 ]

--- a/src/genome_entropy/entropy/shannon.py
+++ b/src/genome_entropy/entropy/shannon.py
@@ -70,6 +70,9 @@ class EntropyReport:
         three_di_entropy: Dictionary mapping ORF IDs to their 3Di token entropy
         alphabet_sizes: Dictionary with alphabet sizes for each representation
         twelve_state_entropy: Optional mapping of ORF IDs to 12-state entropy
+        three_di_twelve_state_mutual_information: Optional mapping of ORF IDs
+            to raw mutual information in bits between aligned 3Di and 12-state
+            encodings
     """
 
     dna_entropy_global: float
@@ -78,6 +81,7 @@ class EntropyReport:
     three_di_entropy: Dict[str, float]
     alphabet_sizes: Dict[str, int]
     twelve_state_entropy: Dict[str, float] | None = None
+    three_di_twelve_state_mutual_information: Dict[str, float] | None = None
 
 
 def shannon_entropy(
@@ -128,6 +132,50 @@ def shannon_entropy(
             return entropy / max_entropy if max_entropy > 0 else 0.0
 
     return entropy
+
+
+def mutual_information(sequence_a: str, sequence_b: str) -> float:
+    """Calculate empirical mutual information between aligned sequences.
+
+    The value is reported in bits from the observed joint distribution. Both
+    sequences must describe the same residue positions.
+
+    Args:
+        sequence_a: First categorical sequence.
+        sequence_b: Second categorical sequence aligned to ``sequence_a``.
+
+    Returns:
+        Raw mutual information in bits. Empty aligned sequences return ``0.0``.
+
+    Raises:
+        ValueError: If the sequences have unequal lengths.
+    """
+    if len(sequence_a) != len(sequence_b):
+        raise ValueError(
+            "Mutual information requires aligned sequences of equal length"
+        )
+    if not sequence_a:
+        return 0.0
+
+    total = len(sequence_a)
+    counts_a = Counter(sequence_a)
+    counts_b = Counter(sequence_b)
+    joint_counts = Counter(zip(sequence_a, sequence_b))
+
+    information = 0.0
+    for (state_a, state_b), joint_count in joint_counts.items():
+        probability_joint = joint_count / total
+        probability_a = counts_a[state_a] / total
+        probability_b = counts_b[state_b] / total
+        information += probability_joint * math.log2(
+            probability_joint / (probability_a * probability_b)
+        )
+
+    # Mutual information is non-negative; preserve meaningful errors while
+    # removing only possible floating-point noise.
+    if -1e-12 < information < 0:
+        return 0.0
+    return information
 
 
 def calculate_sequence_entropy(

--- a/src/genome_entropy/io/jsonio.py
+++ b/src/genome_entropy/io/jsonio.py
@@ -11,7 +11,7 @@ from ..logging_config import get_logger
 logger = get_logger(__name__)
 
 # Schema version for tracking output format changes
-SCHEMA_VERSION = "2.1.0"
+SCHEMA_VERSION = "2.2.0"
 
 
 def to_json_dict(obj: Any) -> Any:
@@ -110,6 +110,11 @@ def convert_pipeline_result_to_unified(pipeline_result):
             if result.entropy.twelve_state_entropy is None
             else result.entropy.twelve_state_entropy.get(orf_id)
         )
+        three_di_twelve_state_mutual_information = (
+            None
+            if result.entropy.three_di_twelve_state_mutual_information is None
+            else result.entropy.three_di_twelve_state_mutual_information.get(orf_id)
+        )
 
         # Build the unified feature
         # Instead of storing the ORF object three times, we extract each
@@ -155,6 +160,9 @@ def convert_pipeline_result_to_unified(pipeline_result):
                 protein_entropy=protein_entropy,
                 three_di_entropy=three_di_entropy,
                 twelve_state_entropy=twelve_state_entropy,
+                three_di_twelve_state_mutual_information=(
+                    three_di_twelve_state_mutual_information
+                ),
             ),
             twelve_state=(
                 None
@@ -220,7 +228,7 @@ def write_json(data: Any, output_path: Union[str, Path], indent: int = 2) -> Non
       - entropy.orf_nt_entropy[id] → features[id].entropy.dna_entropy
 
     NEW FORMAT adds:
-      - schema_version: "2.1.0" (for compatibility tracking)
+      - schema_version: "2.2.0" (for compatibility tracking)
       - features: dict (replaces orfs, proteins, three_dis lists)
       - Hierarchical organization (location, dna, protein, three_di, metadata, entropy)
 
@@ -304,7 +312,8 @@ def read_json(input_path: Union[str, Path]) -> Any:
     with open_func(input_path, mode, encoding="utf-8") as f:
         data = json.load(f)
 
-    # Schema 2.0 and older predate the optional 12-state representation.
+    # Schema 2.0 and older predate the optional 12-state representation, and
+    # schema 2.1 predates mutual information between structural encodings.
     records = data if isinstance(data, list) else [data]
     for record in records:
         if not isinstance(record, dict):
@@ -312,9 +321,15 @@ def read_json(input_path: Union[str, Path]) -> Any:
         for feature in record.get("features", {}).values():
             feature.setdefault("twelve_state", None)
             feature.setdefault("entropy", {}).setdefault("twelve_state_entropy", None)
+            feature["entropy"].setdefault(
+                "three_di_twelve_state_mutual_information", None
+            )
         for structural_record in record.get("three_dis", []):
             structural_record.setdefault("twelve_state", None)
         record.get("entropy", {}).setdefault("twelve_state_entropy", None)
+        record.get("entropy", {}).setdefault(
+            "three_di_twelve_state_mutual_information", None
+        )
 
     logger.info("Successfully read JSON file: %s", input_path)
     return data

--- a/src/genome_entropy/pipeline/runner.py
+++ b/src/genome_entropy/pipeline/runner.py
@@ -20,6 +20,7 @@ from ..entropy.shannon import (
     EntropyReport,
     calculate_sequence_entropy,
     calculate_entropies_for_sequences,
+    mutual_information,
 )
 from ..errors import PipelineError
 from ..io.fasta import read_fasta
@@ -224,6 +225,7 @@ def run_pipeline(
                     three_di_entropy={},
                     alphabet_sizes={},
                     twelve_state_entropy=None,
+                    three_di_twelve_state_mutual_information=None,
                 )
                 results.append(
                     PipelineResult(
@@ -281,6 +283,7 @@ def run_pipeline(
                     three_di_entropy={},
                     alphabet_sizes={},
                     twelve_state_entropy=None,
+                    three_di_twelve_state_mutual_information=None,
                 )
 
             # Create result
@@ -356,6 +359,15 @@ def calculate_pipeline_entropy(
         if twelve_state_sequences
         else None
     )
+    three_di_twelve_state_mutual_information = (
+        {
+            td.protein.orf.orf_id: mutual_information(td.three_di, td.twelve_state)
+            for td in three_dis
+            if td.twelve_state is not None
+        }
+        if twelve_state_sequences
+        else None
+    )
 
     # Alphabet sizes
     alphabet_sizes = {
@@ -374,4 +386,7 @@ def calculate_pipeline_entropy(
         three_di_entropy=three_di_entropy,
         alphabet_sizes=alphabet_sizes,
         twelve_state_entropy=twelve_state_entropy,
+        three_di_twelve_state_mutual_information=(
+            three_di_twelve_state_mutual_information
+        ),
     )

--- a/src/genome_entropy/pipeline/types.py
+++ b/src/genome_entropy/pipeline/types.py
@@ -114,12 +114,16 @@ class FeatureEntropy:
         protein_entropy: Shannon entropy of amino acid sequence
         three_di_entropy: Shannon entropy of 3Di encoding
         twelve_state_entropy: Shannon entropy of 12-state encoding, or ``None``
+        three_di_twelve_state_mutual_information: Raw mutual information in bits
+            between aligned 3Di and 12-state encodings, or ``None`` when the
+            model does not produce both representations
     """
 
     dna_entropy: float
     protein_entropy: float
     three_di_entropy: float
     twelve_state_entropy: float | None = None
+    three_di_twelve_state_mutual_information: float | None = None
 
 
 @dataclass

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -1,6 +1,7 @@
 """Tests for Shannon entropy calculation."""
 
 import math
+from collections import Counter
 
 import pytest
 
@@ -13,6 +14,7 @@ from genome_entropy.entropy.shannon import (
     normalise_protein_entropy,
     normalise_three_di_entropy,
     normalise_twelve_state_entropy,
+    mutual_information,
     shannon_entropy,
 )
 
@@ -42,6 +44,39 @@ def test_representation_normalisation_wrappers() -> None:
 def test_shannon_entropy_empty_string() -> None:
     """Test entropy of empty string is 0."""
     assert shannon_entropy("") == 0.0
+
+
+def test_mutual_information_perfect_coupling() -> None:
+    assert mutual_information("AAAAABBBBB", "AAAAABBBBB") == pytest.approx(1.0)
+    assert mutual_information("AAAAABBBBB", "CCCCCDDDDD") == pytest.approx(1.0)
+
+
+def test_mutual_information_independent_and_constant_variables() -> None:
+    assert mutual_information("AABB", "ABAB") == pytest.approx(0.0)
+    assert mutual_information("AAAAAAAA", "ABCDABCD") == pytest.approx(0.0)
+
+
+def test_mutual_information_empty_and_unequal_inputs() -> None:
+    assert mutual_information("", "") == 0.0
+    with pytest.raises(ValueError, match="aligned sequences of equal length"):
+        mutual_information("ABC", "AB")
+
+
+def test_mutual_information_symmetry_nonnegative_and_entropy_identity() -> None:
+    sequence_a = "AABBAABB"
+    sequence_b = "ABABABAB"
+    information = mutual_information(sequence_a, sequence_b)
+    joint_counts = Counter(zip(sequence_a, sequence_b))
+    joint_entropy = -sum(
+        (count / len(sequence_a)) * math.log2(count / len(sequence_a))
+        for count in joint_counts.values()
+    )
+
+    assert information == pytest.approx(mutual_information(sequence_b, sequence_a))
+    assert information >= 0.0
+    assert information == pytest.approx(
+        shannon_entropy(sequence_a) + shannon_entropy(sequence_b) - joint_entropy
+    )
 
 
 def test_shannon_entropy_single_symbol() -> None:

--- a/tests/test_modernprost_multitask.py
+++ b/tests/test_modernprost_multitask.py
@@ -25,7 +25,7 @@ from genome_entropy.config import (
     resolve_model_name,
 )
 from genome_entropy.encode3di.types import IndexedSeq, StructuralEncoding, ThreeDiRecord
-from genome_entropy.entropy.shannon import shannon_entropy
+from genome_entropy.entropy.shannon import mutual_information, shannon_entropy
 from genome_entropy.errors import ModelError
 from genome_entropy.io.jsonio import read_json, to_json_dict
 from genome_entropy.ml.classifier import extract_features
@@ -283,6 +283,9 @@ def test_pipeline_entropy_reports_twelve_state_or_none() -> None:
     assert report.twelve_state_entropy == {
         "orf1": pytest.approx(shannon_entropy("AABC"))
     }
+    assert report.three_di_twelve_state_mutual_information == {
+        "orf1": pytest.approx(mutual_information("ACDE", "AABC"))
+    }
     assert report.alphabet_sizes["twelve_state"] == 12
 
     _orf, _protein, legacy_record = make_structural_record(None)
@@ -293,6 +296,7 @@ def test_pipeline_entropy_reports_twelve_state_or_none() -> None:
         [legacy_record],
     )
     assert legacy_report.twelve_state_entropy is None
+    assert legacy_report.three_di_twelve_state_mutual_information is None
 
 
 def test_read_json_backfills_older_twelve_state_fields(tmp_path) -> None:
@@ -309,6 +313,12 @@ def test_read_json_backfills_older_twelve_state_fields(tmp_path) -> None:
     loaded = read_json(path)
     assert loaded["features"]["orf1"]["twelve_state"] is None
     assert loaded["features"]["orf1"]["entropy"]["twelve_state_entropy"] is None
+    assert (
+        loaded["features"]["orf1"]["entropy"][
+            "three_di_twelve_state_mutual_information"
+        ]
+        is None
+    )
 
 
 def test_ml_features_include_twelve_state_values() -> None:

--- a/tests/test_unified_output.py
+++ b/tests/test_unified_output.py
@@ -105,7 +105,7 @@ def test_convert_pipeline_result_to_unified():
 
     # Verify top-level fields
     assert isinstance(unified, UnifiedPipelineResult)
-    assert unified.schema_version == "2.1.0"
+    assert unified.schema_version == "2.2.0"
     assert unified.input_id == "test_seq"
     assert unified.input_dna_length == 100
     assert unified.dna_entropy_global == 1.8
@@ -151,6 +151,7 @@ def test_convert_pipeline_result_to_unified():
     assert feature.entropy.dna_entropy == 1.2
     assert feature.entropy.protein_entropy == 0.8
     assert feature.entropy.three_di_entropy == 0.0
+    assert feature.entropy.three_di_twelve_state_mutual_information is None
 
 
 def test_conversion_handles_multiple_features():
@@ -327,6 +328,7 @@ def test_unified_json_serialization():
     three_di = ThreeDiRecord(
         protein=protein,
         three_di="ABC",
+        twelve_state="ABC",
         method="prostt5_aa2fold",
         model_name="test",
         inference_device="cpu",
@@ -338,6 +340,8 @@ def test_unified_json_serialization():
         protein_aa_entropy={"orf_1": 0.8},
         three_di_entropy={"orf_1": 0.5},
         alphabet_sizes={"dna": 4, "protein": 20, "three_di": 20},
+        twelve_state_entropy={"orf_1": 1.5},
+        three_di_twelve_state_mutual_information={"orf_1": 1.5},
     )
 
     old_result = PipelineResult(
@@ -355,7 +359,7 @@ def test_unified_json_serialization():
 
     # Verify JSON structure
     assert "schema_version" in json_dict
-    assert json_dict["schema_version"] == "2.1.0"
+    assert json_dict["schema_version"] == "2.2.0"
     assert "input_id" in json_dict
     assert "input_dna_length" in json_dict
     assert "dna_entropy_global" in json_dict
@@ -373,6 +377,7 @@ def test_unified_json_serialization():
     assert "three_di" in feature_dict
     assert "metadata" in feature_dict
     assert "entropy" in feature_dict
+    assert feature_dict["entropy"]["three_di_twelve_state_mutual_information"] == 1.5
 
     # Verify no redundancy (nt_sequence appears only once)
     import json as json_module


### PR DESCRIPTION
## Summary

Adds per-ORF mutual information between the aligned 3Di and 12-state
representations produced by dual-head ModernProst models.

The implementation:

- calculates empirical mutual information in bits;
- uses the paired categorical structural states from the existing model pass;
- does not store the intermediate 12 × 20 contingency table;
- reports `null` for models without 12-state output;
- preserves backward compatibility with older JSON;
- does not change existing machine-learning feature schemas.

## Definition

`I(3Di;12st) = H(3Di) + H(12st) - H(3Di,12st)`

equivalently calculated directly from the joint state frequencies.

## Validation

- focused unit tests: passed (`PYTHONPATH=src pytest -q tests/test_entropy.py`, 20 passed)
- complete pytest: blocked by missing `PyGeneticCode`, `typer`, and pytest-asyncio in the available interpreter
- Ruff for changed implementation and MI tests: passed
- Black: unavailable; the repository virtual environment has a missing Python interpreter
- mypy: unavailable
- documentation build: blocked because Sphinx is unavailable
- ModernProst 50M smoke test: blocked by missing runtime dependencies/model environment
- legacy 3Di-only smoke test: covered by focused pipeline integration test, but its module cannot import without `PyGeneticCode`
