### PR TITLE
Release 0.2.0: Structural Duet

### DIFF
--- a/VERSION_MANAGEMENT.md
+++ b/VERSION_MANAGEMENT.md
@@ -1,6 +1,6 @@
 # Version management
 
-`pyproject.toml` is the single authoritative package-version source. The current version is `0.1.15`.
+`pyproject.toml` is the single authoritative package-version source. The current version is `0.2.0`.
 
 `src/genome_entropy/__init__.py` and `docs/source/conf.py` read installed metadata through `importlib.metadata.version("genome_entropy")`; the CLI imports that value for `--version`. The package requires Python 3.10 or newer and CI tests 3.10, 3.11, and 3.12.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,8 +1,15 @@
 Changelog
 =========
 
-Unreleased
-----------
+0.2.0 — 17 August 2026
+----------------------
+
+Structural-state analysis
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Added raw per-ORF mutual information in bits between aligned 3Di and
+  12-state ModernProst representations. The schema is now version 2.2; legacy
+  3Di-only output remains compatible and reports the new field as ``null``.
 
 Fixes
 ^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "genome_entropy"
-version = "0.1.16"
+version = "0.2.0"
 description = "Quantify information content across multiple biological representations derived from genomic sequences"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares version 0.2.0, **Structural Duet**.

- bumps the authoritative package version from 0.1.16 to 0.2.0;
- records the 3Di--12-state mutual-information feature in the changelog;
- updates the version-management reference.

## Validation

- parsed `pyproject.toml` with Python `tomllib` and confirmed version `0.2.0`;
- `git diff --check` passed.

The tag `v0.2.0` and a draft GitHub release should be created after this
protected-branch PR merges.
